### PR TITLE
Fixed build.zig in examples

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -30,7 +30,7 @@ fn makeExe(b: *Builder, target: CrossTarget, mode: Mode, root: []const u8) !void
     exe.install();
     exe.addPackage(.{
         .name = "win32",
-        .path = .{ .path = "../zigwin32/win32.zig" },
+        .path = "../zigwin32/win32.zig",
     });
 
     //const run_cmd = exe.run();


### PR DESCRIPTION
I've fixed syntax error when compiling examples with ZIG 0.8
https://ziglearn.org/chapter-3/#packages