### PR TITLE
Add HDPA and HDSA to the known handles list

### DIFF
--- a/src/handletypes.zig
+++ b/src/handletypes.zig
@@ -111,5 +111,7 @@ pub const handle_types = list: {
         .{ "PSID", .{} },
         .{ "AUTHZ_AUDIT_EVENT_HANDLE", .{} },
         .{ "HeapHandle", .{} },
+        .{ "HDPA", .{} },
+        .{ "HDSA", .{} },
     });
 };


### PR DESCRIPTION
In v15.0.2-preview of the win32metadata project the handle types HDPA and HDSA were added to replace the faulty _DPA and _DSA types. Currently HDPA and HDSA get exposed as isize they should get exposed as *opaque.