### PR TITLE
Mark calls to meta.declarations as comptime

### DIFF
--- a/src/genzig.zig
+++ b/src/genzig.zig
@@ -794,12 +794,12 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, tree: json.ValueTree) !
     }
     try writer.writeBlock(comptime removeCr(
         \\    @setEvalBranchQuota(
-        \\        @import("std").meta.declarations(@This()).len * 3
+        \\        comptime @import("std").meta.declarations(@This()).len * 3
         \\    );
         \\
         \\    // reference all the pub declarations
         \\    if (!@import("builtin").is_test) return;
-        \\    inline for (@import("std").meta.declarations(@This())) |decl| {
+        \\    inline for (comptime @import("std").meta.declarations(@This())) |decl| {
         \\        if (decl.is_pub) {
         \\            _ = decl;
         \\        }


### PR DESCRIPTION
On zig master `0.10.0-dev.1649+7e47f106c` running `zig test win32.zig` gives thousands of errors like the below:
```
./win32/ui/xaml/diagnostics.zig:618:55: error: expected type 'u32', found 'usize'
        @import("std").meta.declarations(@This()).len * 3
                                                      ^
./win32/ui/xaml/diagnostics.zig:618:55: note: unsigned 32-bit int cannot represent all possible unsigned 64-bit values
        @import("std").meta.declarations(@This()).len * 3
                                                      ^
./win32/ui/shell/common.zig:274:55: error: expected type 'u32', found 'usize'
        @import("std").meta.declarations(@This()).len * 3
                                                      ^
./win32/ui/shell/common.zig:274:55: note: unsigned 32-bit int cannot represent all possible unsigned 64-bit values
        @import("std").meta.declarations(@This()).len * 3
                                                      ^
./win32/system/com/structured_storage.zig:1724:55: error: expected type 'u32', found 'usize'
        @import("std").meta.declarations(@This()).len * 3
                                                      ^
./win32/system/com/structured_storage.zig:1724:55: note: unsigned 32-bit int cannot represent all possible unsigned 64-bit values
        @import("std").meta.declarations(@This()).len * 3
```

It seems like there has been a change requiring explicit comptime markings on both calls to `std.meta.declarations`.