### PR TITLE
Update to Zig master

### DIFF
--- a/examples/build.zig
+++ b/examples/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *Builder) !void {
     if (builtin.os.tag != .windows) {
         if (target.os_tag == null or target.os_tag.? != .windows) {
             std.log.err("target is not windows", .{});
-            std.log.info("try building with one of -Dtarget=native-windows, -Dtarget=i386-windows or -Dtarget=x86_64-windows\n", .{});
+            std.log.info("try building with one of -Dtarget=native-windows, -Dtarget=x86-windows or -Dtarget=x86_64-windows\n", .{});
             std.os.exit(1);
         }
     }

--- a/src/zig.zig
+++ b/src/zig.zig
@@ -29,7 +29,7 @@ pub usingnamespace switch (unicode_mode) {
 
 pub const Arch = enum { X86, X64, Arm64 };
 pub const arch: Arch = switch (builtin.target.cpu.arch) {
-    .i386 => .X86,
+    .x86 => .X86,
     .x86_64 => .X64,
     .arm, .armeb => .Arm64,
     else => @compileError("unable to determine win32 arch"),


### PR DESCRIPTION
`i386` got renamed to `x86` in https://github.com/ziglang/zig/commit/f5f1f8c66625237e4eceb3cd40597a687e9a58ac