### PR TITLE
Let the user decide if they want ANSI or UNICODE version of the windows API

### DIFF
--- a/src/zig.zig
+++ b/src/zig.zig
@@ -5,10 +5,7 @@ const testing = std.testing;
 
 const root = @import("root");
 pub const UnicodeMode = enum { ansi, wide, unspecified };
-// WORKAROUND: https://github.com/ziglang/zig/issues/7979
-// using root.UNICODE causes an erroneous dependency loop, so I'm hardcoding to .wide for now
-pub const unicode_mode = UnicodeMode.wide;
-//pub const unicode_mode : UnicodeMode = if (@hasDecl(root, "UNICODE")) (if (root.UNICODE) .wide else .ansi) else .unspecified;
+pub const unicode_mode: UnicodeMode = if (@hasDecl(root, "UNICODE")) (if (root.UNICODE) .wide else .ansi) else .unspecified;
 
 pub const L = std.unicode.utf8ToUtf16LeStringLiteral;
 


### PR DESCRIPTION
Letting the user decides which version of the WINAPI they want to use now works with the self-hosted compiler.

Tested with my hand-edited fork: https://github.com/Cold-Bytes-Games/zigwin32/blob/main/win32/zig.zig#L6-L8

* With my game in ANSI mode (closed source)
* With wwise-zig-demo in UNICODE mode:  https://github.com/Cold-Bytes-Games/wwise-zig-demo/blob/v2022.1/src/main.zig#L10-L11