### PR TITLE
Add union pointer specification for `UI.WindowsAndMessaging` constants

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -111,7 +111,7 @@ fn runStepMake(
 ) anyerror!void {
     original_make_fn(step, prog_node) catch |err| switch (err) {
         // just exit if subprocess failed with error exit code
-        error.UnexpectedExitCode => std.os.exit(0xff),
+        error.UnexpectedExitCode => std.process.exit(0xff),
         else => |e| return e,
     };
 }

--- a/examples/unionpointers.zig
+++ b/examples/unionpointers.zig
@@ -91,7 +91,8 @@ pub export fn wWinMain(
         // Well this sucks...ptr and const cast?
         const old_cursor = win32.SetCursor(@constCast(@ptrCast(win32.IDC_ARROW)));
         defer _ = win32.SetCursor(old_cursor);
-        // TODO: get the other IDC_* constants working
+        _ = win32.SetCursor(@constCast(@ptrCast(win32.IDC_IBEAM)));
+        _ = win32.SetCursor(@constCast(@ptrCast(win32.IDC_WAIT)));
     }
 
 

--- a/src/common.zig
+++ b/src/common.zig
@@ -6,7 +6,7 @@ pub const Nothing = struct {};
 
 pub fn fatal(comptime fmt: []const u8, args: anytype) noreturn {
     std.log.err(fmt, args);
-    std.os.exit(0xff);
+    std.process.exit(0xff);
 }
 
 pub fn getcwd(a: std.mem.Allocator) ![]u8 {

--- a/src/pass1.zig
+++ b/src/pass1.zig
@@ -21,7 +21,7 @@ pub fn fatalTrace(trace: ?*std.builtin.StackTrace, comptime fmt: []const u8, arg
     } else {
         std.log.err("no error return trace", .{});
     }
-    std.os.exit(0xff);
+    std.process.exit(0xff);
 }
 
 pub fn main() !u8 {

--- a/unionpointers.json
+++ b/unionpointers.json
@@ -1,9 +1,67 @@
 {
-    "UI.WindowsAndMessaging": {
-        "Functions": {
-            "CreateWindowExA": ["lpClassName"]
-            ,"CreateWindowExW": ["lpClassName"]
-        }
-    }
+  "System.LibraryLoader": {
+    "Functions": {
+      "ENUMRESLANGPROCW": ["lpType"],
+      "ENUMRESNAMEPROCW": ["lpType"],
+      "EnumResourceLanguagesW": ["lpType"],
+      "EnumResourceLanguagesExW": ["lpType"],
+      "EnumResourceNamesW": ["lpType"],
+      "EnumResourceNamesExW": ["lpType"],
+      "FindResourceW": ["lpType"],
+      "FindResourceExW": ["lpType"],
+      "UpdateResourceW": ["lpType"]
+    },
+    "Constants": []
+  },
+  "UI.WindowsAndMessaging": {
+    "Functions": {
+      "CreateWindowExA": ["lpClassName"],
+      "CreateWindowExW": ["lpClassName"],
+      "LoadCursorW": ["lpCursorName"],
+      "LoadIconW": ["lpIconName"]
+    },
+    "Constants": [
+      "IDC_ARROW",
+      "IDC_IBEAM",
+      "IDC_WAIT",
+      "IDC_CROSS",
+      "IDC_UPARROW",
+      "IDC_SIZE",
+      "IDC_ICON",
+      "IDC_SIZENWSE",
+      "IDC_SIZENESW",
+      "IDC_SIZEWE",
+      "IDC_SIZENS",
+      "IDC_SIZEALL",
+      "IDC_NO",
+      "IDC_HAND",
+      "IDC_APPSTARTING",
+      "IDC_HELP",
+      "IDC_PIN",
+      "IDC_PERSON",
+      "IDI_APPLICATION",
+      "IDI_HAND",
+      "IDI_QUESTION",
+      "IDI_EXCLAMATION",
+      "IDI_ASTERISK",
+      "IDI_WINLOGO",
+      "IDI_SHIELD",
+      "RT_VERSION",
+      "RT_DLGINCLUDE",
+      "RT_PLUGPLAY",
+      "RT_VXD",
+      "RT_ANICURSOR",
+      "RT_ANIICON",
+      "RT_HTML",
+      "RT_CURSOR",
+      "RT_BITMAP",
+      "RT_ICON",
+      "RT_MENU",
+      "RT_DIALOG",
+      "RT_FONTDIR",
+      "RT_FONT",
+      "RT_ACCELERATOR",
+      "RT_MESSAGETABLE"
+    ]
+  }
 }
-


### PR DESCRIPTION
Fixes issue #30: _Ability to define alignment/union_pointer constants similar to function params_

- Add ability to specify constants as union pointers.
- Update `std.os.exit` to `std.process.exit` to allow code to build with zig v0.12.0-dev.3496+a2df84d0f
- Update `removeCr` to be able to be called at comptime with zig v0.12.0-dev.3496+a2df84d0f
- Remove constant skips for `IDC_*`, `IDI_*`, and `RT_*` variables
- Add union pointer specification for `IDC_*`, `IDI_*`, and `RT_*` constants and add the corresponding function arguments that expect these constants as union pointers as well.