### PR TITLE
feat: Support for build.zig.zon

### DIFF
--- a/src/genzig.zig
+++ b/src/genzig.zig
@@ -459,6 +459,7 @@ pub fn main() !u8 {
             try src_dir.copyFile(mod ++ ".zig", out_win32_dir, mod ++ ".zig", .{});
         }
         try src_dir.copyFile("zigwin32.build.zig", out_dir, "build.zig", .{});
+        try src_dir.copyFile("zigwin32.build.zig.zon", out_dir, "build.zig.zon", .{});
     }
     print_time_summary = true;
 

--- a/src/zigwin32.build.zig.zon
+++ b/src/zigwin32.build.zig.zon
@@ -1,0 +1,33 @@
+.{
+    .name = "zigwin32",
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "25.0.28",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    .minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{},
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package.
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "win32",
+        "win32.zig",
+        "LICENSE",
+        "README.md",
+    },
+}


### PR DESCRIPTION
Add support for `v0.12.0`'s new `zig fetch --save` command by adding a `build.zig.zon` to the generation.

Fixes #33 