### PR TITLE
replace method mixins with fields for all base types

### DIFF
--- a/examples/d2dcircle.zig
+++ b/examples/d2dcircle.zig
@@ -34,7 +34,7 @@ const BaseWindow = basewin.BaseWindow;
 
 fn SafeRelease(ppT: anytype) void {
     if (ppT.*) |t| {
-        _ = t.IUnknown_Release();
+        _ = t.IUnknown.Release();
         ppT.* = null;
     }
 }
@@ -97,7 +97,7 @@ fn MainWindowCreateGraphicsResources(self: *MainWindow) HRESULT
         {
             const color = D2D1.ColorF(.{ .r = 1, .g = 1, .b = 0});
             // TODO: how do I do this ptrCast better by using COM base type?
-            hr = self.pRenderTarget.?.ID2D1RenderTarget_CreateSolidColorBrush(&color, null, &self.pBrush);
+            hr = self.pRenderTarget.?.ID2D1RenderTarget.CreateSolidColorBrush(&color, null, &self.pBrush);
 
             if (SUCCEEDED(hr))
             {
@@ -122,14 +122,14 @@ fn MainWindowOnPaint(self: *MainWindow) void
         var ps : win32.PAINTSTRUCT = undefined;
         _ = win32.BeginPaint(self.base.m_hwnd.?, &ps);
 
-        self.pRenderTarget.?.ID2D1RenderTarget_BeginDraw();
+        self.pRenderTarget.?.ID2D1RenderTarget.BeginDraw();
 
-        self.pRenderTarget.?.ID2D1RenderTarget_Clear(&D2D1.ColorFU32(.{ .rgb = D2D1.SkyBlue }));
+        self.pRenderTarget.?.ID2D1RenderTarget.Clear(&D2D1.ColorFU32(.{ .rgb = D2D1.SkyBlue }));
         // TODO: how do I get a COM interface type to convert to a base type without
         //       an explicit cast like this?
-        self.pRenderTarget.?.ID2D1RenderTarget_FillEllipse(&self.ellipse, &self.pBrush.?.ID2D1Brush);
+        self.pRenderTarget.?.ID2D1RenderTarget.FillEllipse(&self.ellipse, &self.pBrush.?.ID2D1Brush);
 
-        hr = self.pRenderTarget.?.ID2D1RenderTarget_EndDraw(null, null);
+        hr = self.pRenderTarget.?.ID2D1RenderTarget.EndDraw(null, null);
         if (FAILED(hr) or hr == win32.D2DERR_RECREATE_TARGET)
         {
             self.DiscardGraphicsResources();

--- a/examples/opendialog.zig
+++ b/examples/opendialog.zig
@@ -50,21 +50,21 @@ pub export fn wWinMain(__: win32.HINSTANCE, _: ?win32.HINSTANCE, ___: [*:0]u16, 
             fatal("create FileOpenDialog failed, hr={}", .{hr});
         break :blk dialog.?;
     };
-    defer _ = dialog.IUnknown_Release();
+    defer _ = dialog.IUnknown.Release();
 
     {
-        const hr = dialog.IModalWindow_Show(null);
+        const hr = dialog.IModalWindow.Show(null);
         if (win32.FAILED(hr))
             fatal("show dialog failed, hr={}", .{hr});
     }
 
     var pItem: ?*win32.IShellItem = undefined;
     {
-        const hr = dialog.IFileDialog_GetResult(&pItem);
+        const hr = dialog.IFileDialog.GetResult(&pItem);
         if (win32.FAILED(hr))
             fatal("get dialog result failed, hr={}", .{hr});
     }
-    defer _ = pItem.?.IUnknown_Release();
+    defer _ = pItem.?.IUnknown.Release();
 
     const file_path = blk: {
         var file_path : ?[*:0]u16 = undefined;

--- a/examples/wasapi.zig
+++ b/examples/wasapi.zig
@@ -14,7 +14,7 @@ const win32 = struct {
 };
 
 pub fn getDefaultDevice() !void {
-    var enumerator: ?*win32.IMMDeviceEnumerator = undefined;
+    var enumerator: *win32.IMMDeviceEnumerator = undefined;
 
     {
         const status = win32.CoCreateInstance(
@@ -29,19 +29,23 @@ pub fn getDefaultDevice() !void {
             return error.Fail;
         }
     }
-    defer _ = enumerator.?.IUnknown_Release();
+    defer _ = enumerator.IUnknown.Release();
 
-    log("pre enumerator: {}", .{enumerator.?});
+    log("pre enumerator: {}", .{enumerator});
 
     var device: ?*win32.IMMDevice = undefined;
     {
-        const status = enumerator.?.GetDefaultAudioEndpoint(win32.EDataFlow.eCapture, win32.ERole.eCommunications, &device);
+        const status = enumerator.GetDefaultAudioEndpoint(
+            win32.EDataFlow.eCapture,
+            win32.ERole.eCommunications,
+            &device,
+        );
         if (win32.FAILED(status)) {
             log("DEVICE STATUS: {d}", .{status});
             return error.Fail;
         }
     }
-    defer _ = device.?.IUnknown_Release(); // No such method
+    defer _ = device.?.IUnknown.Release(); // No such method
 
     var properties: ?*win32.IPropertyStore = undefined;
     {


### PR DESCRIPTION
This adds all base types (aka interfaces) going up the inheritance tree
as union fields for every COM base type.  This removes the need for the
method mixins as any inherited method can be called through a single field.
i.e. instead of:

    foo.IUnknown_Release();

you now do:

    foo.IUnknown.Release();

Note that the method names no longer need to be namespaced as well.  In
a future change we'd still like to get to:

    foo.Release();

if possible.  To accomplish this we'll need to check for symbol conflicts
between all inherited interfaces and remove all but one of the conflicting
symbols. We would probably give precedence to the type/interface furthest
down the inheritance tree and also note that you'll still be able to call
any methods that were omitted through the appropriate union field.