### PR TITLE
reorganize everything

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -65,6 +65,21 @@ pub fn build(b: *Build) !void {
         break :blk out_file;
     };
 
+    const newpass1_out_dir = blk: {
+        const exe = b.addExecutable(.{
+            .name = "newpass1",
+            .root_source_file = b.path("src/newpass1.zig"),
+            .optimize = optimize,
+            .target = b.host,
+        });
+        const run = b.addRunArtifact(exe);
+        run.addDirectoryArg(win32json_dep.path(""));
+        const out_dir = run.addOutputDirectoryArg("newpass1");
+        b.step("newpass1", "Reorganize metadata by DLL").dependOn(&run.step);
+        break :blk out_dir;
+    };
+    _ = newpass1_out_dir;
+
     const gen_out_dir = blk: {
         const exe = b.addExecutable(.{
             .name = "genzig",

--- a/src/common.zig
+++ b/src/common.zig
@@ -61,6 +61,27 @@ pub fn formatSliceT(comptime T: type, comptime spec: []const u8, slice: []const 
 //    return .{ .slice = slice };
 //}
 
+pub fn cleanDir(dir: std.fs.Dir, sub_path: []const u8) !void {
+    std.log.info("cleandir '{s}'", .{sub_path});
+    try dir.deleteTree(sub_path);
+    const MAX_ATTEMPTS = 30;
+    var attempt: u32 = 1;
+    while (true) : (attempt += 1) {
+        if (attempt > MAX_ATTEMPTS)
+            fatal("failed to delete '{s}' after {} attempts", .{ sub_path, MAX_ATTEMPTS });
+
+        // ERROR: windows.OpenFile is not handling error.Unexpected NTSTATUS=0xc0000056
+        dir.makeDir(sub_path) catch |e| switch (e) {
+            else => {
+                std.debug.print("[DEBUG] makedir failed with {}\n", .{e});
+                //std.process.exit(0xff);
+                continue;
+            },
+        };
+        break;
+    }
+}
+
 pub fn jsonPanic() noreturn {
     @panic("an assumption about the json format was violated");
 }

--- a/src/genzig.zig
+++ b/src/genzig.zig
@@ -324,7 +324,7 @@ pub fn main() !u8 {
     // no need to free
     try readComOverloads(&global_com_overloads, com_overloads_filename);
 
-    try cleanDir(std.fs.cwd(), zigwin32_out_path);
+    try common.cleanDir(std.fs.cwd(), zigwin32_out_path);
     var out_dir = try std.fs.cwd().openDir(zigwin32_out_path, .{});
     defer out_dir.close();
     try out_dir.makeDir("win32");
@@ -3399,26 +3399,5 @@ fn removeCr(comptime s: []const u8) [withoutCrLen(s):0]u8 {
         }
         std.debug.assert(i == len);
         return without_cr;
-    }
-}
-
-fn cleanDir(dir: std.fs.Dir, sub_path: []const u8) !void {
-    std.log.info("cleandir '{s}'", .{sub_path});
-    try dir.deleteTree(sub_path);
-    const MAX_ATTEMPTS = 30;
-    var attempt: u32 = 1;
-    while (true) : (attempt += 1) {
-        if (attempt > MAX_ATTEMPTS)
-            fatal("failed to delete '{s}' after {} attempts", .{ sub_path, MAX_ATTEMPTS });
-
-        // ERROR: windows.OpenFile is not handling error.Unexpected NTSTATUS=0xc0000056
-        dir.makeDir(sub_path) catch |e| switch (e) {
-            else => {
-                std.debug.print("[DEBUG] makedir failed with {}\n", .{e});
-                //std.process.exit(0xff);
-                continue;
-            },
-        };
-        break;
     }
 }

--- a/src/newpass1.zig
+++ b/src/newpass1.zig
@@ -1,0 +1,181 @@
+const std = @import("std");
+const json = std.json;
+
+const common = @import("common.zig");
+const StringPool = @import("stringpool.zig").StringPool;
+
+fn oom(e: error{OutOfMemory}) noreturn { @panic(@errorName(e)); }
+
+const jsonObjGetRequired = common.jsonObjGetRequired;
+const jsonObjEnforceKnownFieldsOnly = common.jsonObjEnforceKnownFieldsOnly;
+
+var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+const allocator = arena.allocator();
+
+pub fn fatalTrace(trace: ?*std.builtin.StackTrace, comptime fmt: []const u8, args: anytype) noreturn {
+    std.log.err(fmt, args);
+    if (trace) |t| {
+        std.debug.dumpStackTrace(t.*);
+    } else {
+        std.log.err("no error return trace", .{});
+    }
+    std.process.exit(0xff);
+}
+
+pub fn main() !u8 {
+    const start_time = std.time.milliTimestamp();
+    const all_args = try std.process.argsAlloc(allocator);
+    // don't care about freeing args
+
+    const cmd_args = all_args[1..];
+    if (cmd_args.len != 2) {
+        std.log.err("expected 2 arguments but got {}", .{cmd_args.len});
+        return 1;
+    }
+    const win32json_path = cmd_args[0];
+    const out_path = cmd_args[1];
+
+    var win32json_dir = try std.fs.cwd().openDir(win32json_path, .{});
+    defer win32json_dir.close();
+
+    var api_dir = try win32json_dir.openDir("api", .{ .iterate = true });
+    defer api_dir.close();
+
+    var api_list = std.ArrayList([]const u8).init(allocator);
+    defer {
+        for (api_list.items) |api_name| {
+            allocator.free(api_name);
+        }
+        api_list.deinit();
+    }
+    try common.readApiList(api_dir, &api_list);
+
+    // sort so our data is always in the same order
+    std.mem.sort([]const u8, api_list.items, {}, common.asciiLessThanIgnoreCase);
+
+
+    try common.cleanDir(std.fs.cwd(), out_path);
+    var out_dir = try std.fs.cwd().openDir(out_path, .{});
+    defer out_dir.close();
+
+
+    var dll_jsons = DllJsons{
+        .out_dir = out_dir,
+        .string_pool = StringPool.init(allocator),
+    };
+
+    for (api_list.items) |api_json_basename| {
+        const content = blk: {
+            var file = try api_dir.openFile(api_json_basename, .{});
+            defer file.close();
+            break :blk try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+        };
+        defer allocator.free(content);
+        const start = if (std.mem.startsWith(u8, content, "\xEF\xBB\xBF")) 3 else @as(usize, 0);
+        var json_tree = blk: {
+            // TODO: call parseFromSliceLeaky because we are using an arena allocator?
+            break :blk json.parseFromSlice(json.Value, allocator, content[start..], .{}) catch |e|
+                fatalTrace(@errorReturnTrace(), "failed to parse '{s}' with {s}", .{api_json_basename, @errorName(e)});
+        };
+        defer json_tree.deinit();
+        const root_obj = json_tree.value.object;
+        try jsonObjEnforceKnownFieldsOnly(root_obj, &.{ "Constants", "Types", "Functions", "UnicodeAliases" }, api_json_basename);
+        const functions = (try jsonObjGetRequired(root_obj, "Functions", api_json_basename)).array;
+        try writeFunctions(&dll_jsons, api_json_basename, functions);
+        dll_jsons.closeAll();
+    }
+
+    std.log.info("finalizing DLL json files...", .{});
+    {
+        var it = dll_jsons.dll_map.iterator();
+        while (it.next()) |entry| {
+            const out_json = try dll_jsons.open(entry.key_ptr.*);
+            std.debug.assert(out_json.is_first == false);
+            defer out_json.file.close();
+            try out_json.file.writer().writeAll("]\n");
+        }
+    }
+    const run_time = std.time.milliTimestamp() - start_time;
+    std.log.info("took {} ms to write {} DLL json files to {s}", .{run_time, dll_jsons.dll_map.size, out_path});
+    return 0;
+}
+
+const DllJson = struct {
+    maybe_open_file: ?std.fs.File = null,
+    fn close(self: *DllJson) void {
+        if (self.maybe_open_file) |*open_file| {
+            open_file.close();
+            self.maybe_open_file = null;
+        }
+    }
+};
+
+const DllJsons = struct {
+    out_dir: std.fs.Dir,
+    string_pool: StringPool,
+    dll_map: std.StringHashMapUnmanaged(DllJson) = .{},
+    pub fn closeAll(self: DllJsons) void {
+        var it = self.dll_map.iterator();
+        while (it.next()) |entry| {
+            entry.value_ptr.close();
+        }
+    }
+    pub fn open(self: *DllJsons, dll_import: []const u8) !struct {
+        is_first: bool,
+        file: std.fs.File,
+    } {
+        const dll_import_pool = blk: {
+            var lower_buf: [100]u8 = undefined;
+            const lower = std.ascii.lowerString(&lower_buf, dll_import);
+            break :blk try self.string_pool.add(lower);
+        };
+        const entry = self.dll_map.getOrPut(allocator, dll_import_pool.slice) catch |e| oom(e);
+
+        const file = blk: {
+            if (entry.found_existing) {
+                if (entry.value_ptr.maybe_open_file) |f| break :blk f;
+                const file = try self.out_dir.openFile(
+                    dll_import_pool.slice,
+                    .{ .mode = .write_only },
+                );
+                try file.seekFromEnd(0);
+                entry.value_ptr.maybe_open_file = file;
+                break :blk file;
+            }
+
+            std.log.info("new dll '{s}'", .{dll_import_pool});
+            const file = try self.out_dir.createFile(
+                dll_import_pool.slice,
+                .{},
+            );
+            entry.value_ptr.* = .{ .maybe_open_file = file };
+            break :blk file;
+        };
+        return .{
+            .is_first = !entry.found_existing,
+            .file = file,
+        };
+    }
+};
+
+fn writeFunctions(
+    dll_jsons: *DllJsons,
+    json_basename: []const u8,
+    functions: json.Array,
+) !void {
+    // TODO: keep a set of all currently open dll files
+
+    for (functions.items) |*function_node_ptr| {
+        const function_obj = function_node_ptr.object;
+        try jsonObjEnforceKnownFieldsOnly(function_obj, &.{
+            "Name", "Platform", "Architectures", "SetLastError", "DllImport",
+            "ReturnType", "ReturnAttrs", "Attrs", "Params",
+        }, json_basename);
+        const dll_import = (try jsonObjGetRequired(function_obj, "DllImport", json_basename)).string;
+        const out_json = try dll_jsons.open(dll_import);
+        const prefix: []const u8 = if (out_json.is_first) "[\n " else ",";
+        try out_json.file.writer().writeAll(prefix);
+        try json.stringify(function_node_ptr.*, .{}, out_json.file.writer());
+        try out_json.file.writer().writeAll("\n");
+    }
+}


### PR DESCRIPTION
This is an exploration/attempt to reorganize the bindings based on DLLs rather than only organizing everything based on the hierarchy established by the upstream metadata project.  The "metadata project hierarchy" is a layer on top of an already existing grouping of functions that the OS has already established.  With ideas to add filtering, making the code generator aware of this lower level organization will give more fine-grained control and dependency aware filtering mechanisms.

Here's the current idea on how to accomplish this:

# Reorg

### Pass 1: Separate Functions into DLLs and associate types/constants
```
ForEach API File:
    ForEach Function:
        append function JSON to <dll_name>.json

    Close all currently open JSON files
    TODO: should we log somewhere all the DLLs that every API contained functions for?
```

While generating the DLL json files, store an association between all types and the DLL's that reference them in memory.  Once finished, write these associates to an extra file for pass2 to use.

Note that "COM objects" are included in these "types".  They are not associated with DLL's like functions are, but, there *might* be functions that come from DLL's that can accept/return COM objects.  These interactions will be captured by the type associations we already established above.

Also note that the metadata project has defined special types for some constants, and we can use those types to know where these constants go.  However, we may need to do some "finagling" for constants where this hasn't been done, namely, codify the patterns Microsoft has established to organize the constants and use those to find their "home".

### Pass 2: Generate Zig

```
For each <dll_name>.json
    open types.json: look at the entry for this dll, and it should list
    all types that we need to pull in.
    As we are pulling in types, if that type is ONLY referenced in this DLL, then
    we generate the definition, otherwise, we generate an import.
    Where should we put the definition if it's referenced in multiple dlls?
    Option: put all common definitions into 1 giant file!
    Option: use "the dll set" as a new file?  Maybe we have a manual configuration
            file to name these dll sets?  For example, if a type is in d3d and d2d, maybe we put it in dx?
```

