### PR TITLE
Update to 0.15.0-dev Io APIs

### DIFF
--- a/0.14.1/common.zig
+++ b/0.14.1/common.zig
@@ -1,0 +1,76 @@
+const builtin = @import("builtin");
+const std = @import("std");
+
+pub fn addExamples(
+    b: *std.Build,
+    optimize: std.builtin.OptimizeMode,
+    win32: *std.Build.Module,
+    examples: std.Build.LazyPath,
+) void {
+    const arches: []const ?[]const u8 = &[_]?[]const u8{
+        null,
+        "x86",
+        "x86_64",
+        "aarch64",
+    };
+    const examples_step = b.step("examples", "Build/run examples. Use -j1 to run one at a time");
+
+    try addExample(b, arches, optimize, win32, examples, "helloworld", .Console, examples_step);
+    try addExample(b, arches, optimize, win32, examples, "wasapi", .Console, examples_step);
+    try addExample(b, arches, optimize, win32, examples, "net", .Console, examples_step);
+    try addExample(b, arches, optimize, win32, examples, "tests", .Console, examples_step);
+
+    try addExample(b, arches, optimize, win32, examples, "helloworld-window", .Windows, examples_step);
+    try addExample(b, arches, optimize, win32, examples, "d2dcircle", .Windows, examples_step);
+    try addExample(b, arches, optimize, win32, examples, "opendialog", .Windows, examples_step);
+    try addExample(b, arches, optimize, win32, examples, "unionpointers", .Windows, examples_step);
+    try addExample(b, arches, optimize, win32, examples, "testwindow", .Windows, examples_step);
+}
+
+fn addExample(
+    b: *std.Build,
+    arches: []const ?[]const u8,
+    optimize: std.builtin.OptimizeMode,
+    win32: *std.Build.Module,
+    examples: std.Build.LazyPath,
+    root: []const u8,
+    subsystem: std.Target.SubSystem,
+    examples_step: *std.Build.Step,
+) !void {
+    const basename = b.fmt("{s}.zig", .{root});
+    for (arches) |cross_arch_opt| {
+        const name = if (cross_arch_opt) |arch| b.fmt("{s}-{s}", .{ root, arch }) else root;
+
+        const arch_os_abi = if (cross_arch_opt) |arch| b.fmt("{s}-windows", .{arch}) else "native";
+        const target_query = std.Target.Query.parse(.{ .arch_os_abi = arch_os_abi }) catch unreachable;
+        const target = b.resolveTargetQuery(target_query);
+        const exe = b.addExecutable(.{
+            .name = name,
+            .root_module = b.createModule(.{
+                .root_source_file = examples.path(b, basename),
+                .target = target,
+                .optimize = optimize,
+                .single_threaded = true,
+            }),
+            .win32_manifest = if (subsystem == .Windows) examples.path(b, "win32.manifest") else null,
+        });
+        exe.subsystem = subsystem;
+        exe.root_module.addImport("win32", win32);
+        examples_step.dependOn(&exe.step);
+        exe.pie = true;
+
+        const desc_suffix: []const u8 = if (cross_arch_opt) |_| "" else " for the native target";
+        const build_desc = b.fmt("Build {s}{s}", .{ name, desc_suffix });
+        b.step(b.fmt("{s}-build", .{name}), build_desc).dependOn(&exe.step);
+
+        const run_cmd = b.addRunArtifact(exe);
+        const run_desc = b.fmt("Run {s}{s}", .{ name, desc_suffix });
+        b.step(name, run_desc).dependOn(&run_cmd.step);
+
+        if (builtin.os.tag == .windows) {
+            if (cross_arch_opt == null) {
+                examples_step.dependOn(&run_cmd.step);
+            }
+        }
+    }
+}

--- a/src/StringPool.zig
+++ b/src/StringPool.zig
@@ -10,14 +10,7 @@ pub const Val = struct {
     pub fn eql(self: Val, other: Val) bool {
         return self.slice.ptr == other.slice.ptr;
     }
-    pub fn format(
-        self: @This(),
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
         return writer.writeAll(self.slice);
     }
 };

--- a/src/common.zig
+++ b/src/common.zig
@@ -38,14 +38,7 @@ pub fn asciiLessThanIgnoreCase(_: void, lhs: []const u8, rhs: []const u8) bool {
 fn SliceFormatter(comptime T: type, comptime spec: []const u8) type {
     return struct {
         slice: []const T,
-        pub fn format(
-            self: @This(),
-            comptime fmt: []const u8,
-            options: std.fmt.FormatOptions,
-            writer: anytype,
-        ) !void {
-            _ = fmt;
-            _ = options;
+        pub fn format(self: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
             var first: bool = true;
             for (self.slice) |e| {
                 if (first) {
@@ -53,7 +46,7 @@ fn SliceFormatter(comptime T: type, comptime spec: []const u8) type {
                 } else {
                     try writer.writeAll(", ");
                 }
-                try std.fmt.format(writer, "{" ++ spec ++ "}", .{e});
+                try writer.printValue(spec, .{}, e, std.options.fmt_max_depth);
             }
         }
     };
@@ -86,20 +79,16 @@ pub fn jsonEnforceMsg(cond: bool, comptime msg: []const u8, args: anytype) void 
 
 const JsonFormatter = struct {
     value: std.json.Value,
-    pub fn format(
-        self: JsonFormatter,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: JsonFormatter, writer: *std.io.Writer) std.io.Writer.Error!void {
         switch (self.value) {
             // avoid issues where std.json adds quotes to big numbers
             // (potential fix: https://github.com/ziglang/zig/pull/16707)
-            .integer => |i| try std.fmt.formatIntValue(i, "", .{}, writer),
+            .integer => |i| try writer.printInt(i, 10, .lower, .{}),
             .number_string => |s| try writer.writeAll(s),
-            else => try std.json.stringify(self.value, .{}, writer),
+
+            // TODO: Compile error until https://github.com/ziglang/zig/issues/24468 is resolved
+            //else => try std.json.stringify(self.value, .{}, writer),
+            else => try writer.writeAll("TODO"),
         }
     }
 };
@@ -119,14 +108,7 @@ pub fn fmtJson(value: anytype) JsonFormatter {
 pub const ComInterface = struct {
     name: []const u8,
     api: []const u8,
-    pub fn format(
-        self: ComInterface,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: ComInterface, writer: *std.io.Writer) std.io.Writer.Error!void {
         try writer.print(
             "{{\"Kind\":\"ApiRef\",\"Name\":\"{s}\",\"TargetKind\":\"Com\",\"Api\":\"{s}\",\"Parents\":[]}}",
             .{ self.name, self.api },
@@ -136,7 +118,7 @@ pub const ComInterface = struct {
 
 pub fn getComInterface(type_ref: metadata.TypeRef) ComInterface {
     const api_ref = switch (type_ref) {
-        .ApiRef => |r| r,
+        .api_ref => |r| r,
         else => jsonPanic(),
     };
     jsonEnforce(api_ref.TargetKind == .Com);

--- a/src/diff.zig
+++ b/src/diff.zig
@@ -7,25 +7,29 @@ pub fn fatal(comptime fmt: []const u8, args: anytype) noreturn {
 
 fn usage(zigbuild: bool) !void {
     const options = "[--nofetch|-n]";
-    const stderr = std.io.getStdErr().writer();
+
+    var buf: [64]u8 = undefined;
+    const w = std.debug.lockStderrWriter(&buf);
+    defer std.debug.unlockStderrWriter();
+
     const parts: struct {
         diffrepo: []const u8,
         generated: []const u8,
     } = blk: {
         if (zigbuild) {
-            try stderr.print("Usage: zig build diff -- {s}\n", .{options});
+            try w.print("Usage: zig build diff -- {s}\n", .{options});
             break :blk .{
                 .diffrepo = "the 'diffrepo' subdirectory",
                 .generated = "the latest generated release",
             };
         }
-        try stderr.print("Usage: diff.exe {s} DIFF_REPO GENERATED_PATH\n", .{options});
+        try w.print("Usage: diff.exe {s} DIFF_REPO GENERATED_PATH\n", .{options});
         break :blk .{
             .diffrepo = "DIFF_REPO",
             .generated = "GENERATED_PATH",
         };
     };
-    try stderr.print(
+    try w.print(
         \\
         \\Updates {s} and installs {s}
         \\on top for diffing purposes.
@@ -147,14 +151,7 @@ fn gitInit(repo: []const u8) !void {
 
 const FormatArgv = struct {
     argv: []const []const u8,
-    pub fn format(
-        self: @This(),
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
         var prefix: []const u8 = "";
         for (self.argv) |arg| {
             try writer.print("{s}{s}", .{ prefix, arg });
@@ -176,14 +173,7 @@ pub fn childProcFailed(term: std.process.Child.Term) bool {
 }
 const FormatTerm = struct {
     term: std.process.Child.Term,
-    pub fn format(
-        self: @This(),
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
         switch (self.term) {
             .Exited => |code| try writer.print("exited with code {}", .{code}),
             .Signal => |sig| try writer.print("exited with signal {}", .{sig}),
@@ -202,11 +192,11 @@ pub fn run(
     argv: []const []const u8,
 ) !void {
     var child = std.process.Child.init(argv, allocator);
-    std.log.info("{}", .{fmtArgv(child.argv)});
+    std.log.info("{f}", .{fmtArgv(child.argv)});
     try child.spawn();
     const term = try child.wait();
     if (childProcFailed(term)) {
-        fatal("{s} {}", .{ name, fmtTerm(term) });
+        fatal("{s} {f}", .{ name, fmtTerm(term) });
     }
 }
 

--- a/src/extra.zig
+++ b/src/extra.zig
@@ -24,8 +24,11 @@ pub fn oom(e: error{OutOfMemory}) noreturn {
     @panic(@errorName(e));
 }
 fn parseError(filename: []const u8, lineno: u32, comptime fmt: []const u8, args: anytype) noreturn {
-    std.io.getStdErr().writer().print("{s}:{}: parse error: ", .{ filename, lineno }) catch |e| std.debug.panic("write to stderr failed with {s}", .{@errorName(e)});
-    std.io.getStdErr().writer().print(fmt, args) catch |e| std.debug.panic("write to stderr failed with {s}", .{@errorName(e)});
+    var buf: [64]u8 = undefined;
+    const w = std.debug.lockStderrWriter(&buf);
+    defer std.debug.unlockStderrWriter();
+    w.print("{s}:{}: parse error: ", .{ filename, lineno }) catch |e| std.debug.panic("write to stderr failed with {s}", .{@errorName(e)});
+    w.print(fmt, args) catch |e| std.debug.panic("write to stderr failed with {s}", .{@errorName(e)});
     std.process.exit(0xff);
 }
 
@@ -49,7 +52,7 @@ pub fn read(
         const first_field = field_it.next() orelse continue;
         if (first_field.len == 0 or first_field[0] == '#') continue;
         const api_name = string_pool.add(first_field) catch |e| oom(e);
-        if (api_name_set.get(api_name)) |_| {} else parseError(filename, lineno, "unknown api '{}'", .{api_name});
+        if (api_name_set.get(api_name)) |_| {} else parseError(filename, lineno, "unknown api '{f}'", .{api_name});
 
         const api = blk: {
             const entry = root.getOrPut(allocator, api_name) catch |e| oom(e);
@@ -68,7 +71,7 @@ pub fn read(
 
             const func = blk: {
                 const entry = api.functions.getOrPut(allocator, func_name) catch |e| oom(e);
-                if (entry.found_existing) parseError(filename, lineno, "duplicate function '{s} {s}'", .{ api_name, func_name });
+                if (entry.found_existing) parseError(filename, lineno, "duplicate function '{f} {f}'", .{ api_name, func_name });
                 entry.value_ptr.* = .{};
                 break :blk entry.value_ptr;
             };
@@ -83,7 +86,7 @@ pub fn read(
                     func.ret = named_mod.modifier;
                 } else {
                     const entry = func.params.getOrPut(allocator, name) catch |e| oom(e);
-                    if (entry.found_existing) parseError(filename, lineno, "duplicate parameter '{s}'", .{name});
+                    if (entry.found_existing) parseError(filename, lineno, "duplicate parameter '{f}'", .{name});
                     entry.value_ptr.* = named_mod.modifier;
                 }
                 next_index = named_mod.end;
@@ -99,7 +102,7 @@ pub fn read(
             if (skipWhitespace(line, named_mod.end) != line.len) parseError(filename, lineno, "unexpected data: '{s}'", .{line[named_mod.end..]});
             const name = string_pool.add(named_mod.name) catch |e| oom(e);
             const entry = api.constants.getOrPut(allocator, name) catch |e| oom(e);
-            if (entry.found_existing) parseError(filename, lineno, "duplicate constant '{s}'", .{name});
+            if (entry.found_existing) parseError(filename, lineno, "duplicate constant '{f}'", .{name});
             entry.value_ptr.* = named_mod.modifier;
         } else parseError(filename, lineno, "unknown kind '{s}'", .{kind});
     }

--- a/src/genzig.zig
+++ b/src/genzig.zig
@@ -20,8 +20,6 @@ const jsonEnforce = common.jsonEnforce;
 const jsonEnforceMsg = common.jsonEnforceMsg;
 const fmtJson = common.fmtJson;
 
-const BufferedWriter = std.io.BufferedWriter(4096, std.fs.File.Writer);
-
 var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
 const allocator = arena.allocator();
 
@@ -126,9 +124,9 @@ const SdkFile = struct {
     const_exports: ArrayList(StringPool.Val),
     uses_guid: bool,
     top_level_api_imports: StringPool.HashMap(ApiImport),
-    // maintin insertion order so they appear in the same order in everything.zig
+    // maintain insertion order so they appear in the same order in everything.zig
     type_exports: StringPoolArrayHashMap(void),
-    // maintin insertion order so they appear in the same order in everything.zig
+    // maintain insertion order so they appear in the same order in everything.zig
     func_exports: StringPoolArrayHashMap(void),
     // this field is only needed to workaround: https://github.com/ziglang/zig/issues/4476
     tmp_func_ptr_workaround_list: ArrayList(StringPool.Val),
@@ -161,7 +159,7 @@ const SdkFile = struct {
         if (self.top_level_api_imports.getPtr(top_level_symbol)) |import| {
             jsonEnforceMsg(
                 api.eql(import.api),
-                "symbol conflict '{s}', api mismatch '{s}' and '{s}'",
+                "symbol conflict '{s}', api mismatch '{f}' and '{f}'",
                 .{ name, api, import.api },
             );
             import.arches = import.arches.unionWith(arches);
@@ -208,14 +206,17 @@ pub fn main() !u8 {
     const com_overloads_filename = cmd_args[3];
     const zigwin32_out_path = stripDotDir(cmd_args[4]);
 
+    var version_buf: [100]u8 = undefined;
     const version = blk: {
         var win32json_dir = try std.fs.cwd().openDir(win32json_path, .{});
         defer win32json_dir.close();
         const file = try win32json_dir.openFile("version.txt", .{});
         defer file.close();
-        break :blk try file.reader().readAllAlloc(allocator, 100);
+
+        var reader = file.readerStreaming(&.{});
+        var writer: std.io.Writer = .fixed(&version_buf);
+        break :blk version_buf[0..try reader.interface.streamRemaining(&writer)];
     };
-    defer allocator.free(version);
     _ = std.SemanticVersion.parse(version) catch |err|
         fatal("version '{s}' is not a valid semantic version: {s}", .{ version, @errorName(err) });
 
@@ -305,7 +306,8 @@ pub fn main() !u8 {
         for (api_list, 0..) |api_name, api_index| {
             const api_num = api_index + 1;
             var basename_buf: [100]u8 = undefined;
-            const basename = std.fmt.bufPrint(&basename_buf, "{}.json", .{api_name}) catch @panic("basename_buf not big enough");
+            const basename = std.fmt.bufPrint(&basename_buf, "{f}.json", .{api_name}) catch
+                @panic("basename_buf not big enough");
             std.debug.print("{}/{}: loading '{s}'\n", .{ api_num, api_list.len, basename });
             //
             // TODO: would things run faster if I just memory mapped the file?
@@ -321,16 +323,23 @@ pub fn main() !u8 {
                 "missing {} entries in ComOverloads.txt, copy/paste the following to it:",
                 .{global_missing_com_overloads.items.len},
             );
-            for (global_missing_com_overloads.items) |overload| {
-                try std.io.getStdErr().writer().print(
-                    "{s} {s} {s} {} TODO_FILL_IN_SUFFIX\n",
-                    .{
-                        overload.api,
-                        overload.com_type,
-                        overload.method,
-                        overload.method_index,
-                    },
-                );
+
+            {
+                var buf: [64]u8 = undefined;
+                const w = std.debug.lockStderrWriter(&buf);
+                defer std.debug.unlockStderrWriter();
+
+                for (global_missing_com_overloads.items) |overload| {
+                    try w.print(
+                        "{f} {s} {s} {} TODO_FILL_IN_SUFFIX\n",
+                        .{
+                            overload.api,
+                            overload.com_type,
+                            overload.method,
+                            overload.method_index,
+                        },
+                    );
+                }
             }
             std.process.exit(0xff);
         }
@@ -349,7 +358,11 @@ pub fn main() !u8 {
     {
         var zon = try out_dir.createFile("build.zig.zon", .{});
         defer zon.close();
-        const w = zon.writer();
+
+        var buf: [64]u8 = undefined;
+        var zon_writer = zon.writer(&buf);
+        var w = &zon_writer.interface;
+
         try w.writeAll(".{\n");
         try w.writeAll("    .name = \"zigwin32\",\n");
         try w.print("    .version = \"{s}\",\n", .{version});
@@ -364,6 +377,7 @@ pub fn main() !u8 {
         try w.writeAll("        \"win32.zig\",\n");
         try w.writeAll("    },\n");
         try w.writeAll("}\n");
+        try w.flush();
     }
     print_time_summary = true;
     return 0;
@@ -378,9 +392,12 @@ fn stripDotDir(path: []const u8) []const u8 {
 fn installStaticFile(out_dir: std.fs.Dir, comptime name: []const u8) !void {
     const file = try out_dir.createFile(name, .{});
     defer file.close();
+
     // NOTE: it's important that we use @embedFile here so that the genzig
     //       executable tracks changes to these files
-    try file.writer().writeAll(@embedFile("static/" ++ name));
+    const contents = @embedFile("static/" ++ name);
+    var writer = file.writer(&.{});
+    try writer.interface.writeAll(contents[0..]);
 }
 
 fn readJson(comptime T: type, filename: []const u8, content: []const u8) T {
@@ -426,7 +443,7 @@ fn readComOverloads(
         if (line.len == 0) continue;
         var field_it = std.mem.tokenizeScalar(u8, line, ' ');
         const api = try global_symbol_pool.add(field_it.next() orelse continue);
-        if (api_name_set.get(api)) |_| {} else fatal("{s} line {}: unknown api '{}'", .{ filename, line_number, api });
+        if (api_name_set.get(api)) |_| {} else fatal("{s} line {}: unknown api '{f}'", .{ filename, line_number, api });
         const com_type = field_it.next() orelse fatal("{s} line {}: missing type field", .{ filename, line_number });
         const method = field_it.next() orelse fatal("{s} line {}: missing method field", .{ filename, line_number });
         const method_index_str = field_it.next() orelse fatal("{s} line {}: missing method index field", .{ filename, line_number });
@@ -457,7 +474,7 @@ fn readComOverloads(
         const suffix_map = method_entry.value_ptr;
         const suffix_entry = try suffix_map.getOrPut(allocator, method_index);
         if (suffix_entry.found_existing) fatal(
-            "api '{s}' type '{s}' method '{s}' has duplicate entries for index {}",
+            "api '{f}' type '{s}' method '{s}' has duplicate entries for index {}",
             .{ api, com_type, method, method_index },
         );
         suffix_entry.value_ptr.* = suffix;
@@ -500,10 +517,12 @@ const Export = struct {
 fn generateEverythingModule(out_win32_dir: std.fs.Dir, root_module: *Module) !void {
     var everything_file = try out_win32_dir.createFile("everything.zig", .{});
     defer everything_file.close();
-    var buffered_writer = BufferedWriter{ .unbuffered_writer = everything_file.writer() };
-    defer buffered_writer.flush() catch @panic("flush failed");
-    const writer = buffered_writer.writer();
-    try writer.writeAll(&comptime removeCr(autogen_header ++
+
+    var buf: [4096]u8 = undefined;
+    var everything_file_writer = everything_file.writer(&buf);
+    var w = &everything_file_writer.interface;
+
+    try w.writeAll(&comptime removeCr(autogen_header ++
         \\//! This module contains aliases to ALL symbols inside the Win32 SDK.  It allows
         \\//! an application to access any and all symbols through a single import.
         \\
@@ -537,24 +556,24 @@ fn generateEverythingModule(out_win32_dir: std.fs.Dir, root_module: *Module) !vo
         }
     }
 
-    try addZigExports(writer.any(), &exports);
+    try addZigExports(w, &exports);
 
     for (sdk_files.items) |sdk_file| {
-        try writer.print("// {s} exports {} constants:\n", .{ sdk_file.zig_name, sdk_file.const_exports.items.len });
+        try w.print("// {s} exports {} constants:\n", .{ sdk_file.zig_name, sdk_file.const_exports.items.len });
         for (sdk_file.const_exports.items) |constant| {
             const result = try exports.getOrPut(constant);
             if (result.found_existing) {
                 const existing = result.value_ptr;
-                try writer.print(
-                    "// omitting constant '{s}.{s}' in favor of {s} '{s}.{1s}'\n",
+                try w.print(
+                    "// omitting constant '{s}.{f}' in favor of {s} '{s}.{1f}'\n",
                     .{ sdk_file.zig_name, constant, @tagName(existing.kind), existing.fileZigName() },
                 );
             } else {
                 result.value_ptr.* = .{ .kind = .constant, .file = .{ .sdk_file = sdk_file } };
-                try writer.print("pub const {s} = @import(\"../win32.zig\").{s}.{0s};\n", .{ constant, sdk_file.zig_name });
+                try w.print("pub const {f} = @import(\"../win32.zig\").{s}.{0f};\n", .{ constant, sdk_file.zig_name });
             }
         }
-        try writer.print("// {s} exports {} types:\n", .{ sdk_file.zig_name, sdk_file.type_exports.count() });
+        try w.print("// {s} exports {} types:\n", .{ sdk_file.zig_name, sdk_file.type_exports.count() });
         var export_it = sdk_file.type_exports.iterator();
         while (export_it.next()) |kv| {
             const type_name = kv.key_ptr.*;
@@ -562,41 +581,42 @@ fn generateEverythingModule(out_win32_dir: std.fs.Dir, root_module: *Module) !vo
             const existing = exports.get(type_name) orelse unreachable;
             std.debug.assert(existing.kind == .type);
             if (existing.fileAsSdk() != sdk_file) {
-                try writer.print(
-                    "// omitting type '{s}.{s}' in favor of {s} '{s}.{1s}'\n",
+                try w.print(
+                    "// omitting type '{s}.{f}' in favor of {s} '{s}.{1f}'\n",
                     .{ sdk_file.zig_name, type_name, @tagName(existing.kind), existing.fileZigName() },
                 );
             } else {
-                try writer.print("pub const {s} = @import(\"../win32.zig\").{s}.{0s};\n", .{ type_name, sdk_file.zig_name });
+                try w.print("pub const {f} = @import(\"../win32.zig\").{s}.{0f};\n", .{ type_name, sdk_file.zig_name });
             }
         }
-        try writer.print("// {s} exports {} functions:\n", .{ sdk_file.zig_name, sdk_file.func_exports.count() });
+        try w.print("// {s} exports {} functions:\n", .{ sdk_file.zig_name, sdk_file.func_exports.count() });
         var func_it = sdk_file.func_exports.iterator();
         while (func_it.next()) |kv| {
             const func = kv.key_ptr.*;
             if (exports.get(func)) |existing| {
-                try writer.print(
-                    "// omitting function '{s}.{s}' in favor of {s} '{s}.{1s}'\n",
+                try w.print(
+                    "// omitting function '{s}.{f}' in favor of {s} '{s}.{1f}'\n",
                     .{ sdk_file.zig_name, func, @tagName(existing.kind), existing.fileZigName() },
                 );
             } else {
-                try writer.print("pub const {s} = @import(\"../win32.zig\").{s}.{0s};\n", .{ func, sdk_file.zig_name });
+                try w.print("pub const {f} = @import(\"../win32.zig\").{s}.{0f};\n", .{ func, sdk_file.zig_name });
                 try exports.put(func, .{ .kind = .function, .file = .{ .sdk_file = sdk_file } });
             }
         }
     }
+    try w.flush();
 }
 
-fn addZigExports(writer: std.io.AnyWriter, exports: *StringPool.HashMap(Export)) !void {
+fn addZigExports(writer: *std.io.Writer, exports: *StringPool.HashMap(Export)) !void {
     inline for (zigexports.declarations) |decl| {
         const name = try global_symbol_pool.add(decl.name);
         const result = try exports.getOrPut(name);
         if (result.found_existing) std.debug.panic(
-            "zig.zig {s} export '{}' conflicts with {s} from {s}",
+            "zig.zig {s} export '{f}' conflicts with {s} from {s}",
             .{ @tagName(decl.kind), name, @tagName(result.value_ptr.kind), result.value_ptr.fileZigName() },
         );
         result.value_ptr.* = .{ .kind = decl.kind, .file = .zig };
-        try writer.print("pub const {s} = zig.{0s};\n", .{name});
+        try writer.print("pub const {f} = zig.{0f};\n", .{name});
     }
 }
 
@@ -619,33 +639,35 @@ fn generateContainerModules(dir: std.fs.Dir, module: *Module) anyerror!void {
         break :blk try dir.createFile(module.zig_basename, .{});
     };
     defer file.close();
-    var buffered_writer = BufferedWriter{ .unbuffered_writer = file.writer() };
-    defer buffered_writer.flush() catch @panic("flush failed");
-    const writer = buffered_writer.writer();
+
+    var buf: [4096]u8 = undefined;
+    var file_writer = file.writerStreaming(&buf);
+    var w = &file_writer.interface;
 
     const children = try common.allocMapValues(allocator, *Module, module.children);
     defer allocator.free(children);
 
     std.mem.sort(*Module, children, {}, moduleLessThan);
     if (module.file) |_| {
-        try writer.print("//--------------------------------------------------------------------------------\n", .{});
-        try writer.print("// Section: SubModules ({})\n", .{children.len});
-        try writer.print("//--------------------------------------------------------------------------------\n", .{});
+        try w.print("//--------------------------------------------------------------------------------\n", .{});
+        try w.print("// Section: SubModules ({})\n", .{children.len});
+        try w.print("//--------------------------------------------------------------------------------\n", .{});
     } else {
-        try writer.writeAll(autogen_header);
+        try w.writeAll(autogen_header);
     }
     for (children) |child| {
-        try writer.print("pub const {s} = @import(\"{s}/{0s}.zig\");\n", .{ child.name, module.name.slice });
+        try w.print("pub const {f} = @import(\"{s}/{0f}.zig\");\n", .{ child.name, module.name.slice });
     }
 
     if (module.file) |_| {} else {
-        try writer.writeAll(&comptime removeCr(
+        try w.writeAll(&comptime removeCr(
             \\test {
             \\    @import("std").testing.refAllDecls(@This());
             \\}
             \\
         ));
     }
+    try w.flush();
 
     var next_dir = try dir.openDir(module.name.slice, .{});
     defer next_dir.close();
@@ -724,7 +746,7 @@ fn readAndGenerateApiFile(
         extra_consts = api_obj.constants;
     }
 
-    module.file = SdkFile{
+    module.file = .{
         .json_basename = json_basename_copy,
         .json_name = json_name,
         .zig_name = zig_name,
@@ -767,15 +789,18 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
 
     var out_file = try module_dir.createFile(module.zig_basename, .{});
     defer out_file.close();
-    var buffered_writer = BufferedWriter{ .unbuffered_writer = out_file.writer() };
-    defer buffered_writer.flush() catch @panic("flush failed");
-    var code_writer = CodeWriter{ .writer = buffered_writer.writer(), .depth = 0, .midline = false };
-    // need to specify type explicitly because of https://github.com/ziglang/zig/issues/12795
-    const writer: *CodeWriter = &code_writer;
+
+    var buf: [4096]u8 = undefined;
+    var out_file_writer = out_file.writer(&buf);
+
+    var code_writer: CodeWriter = .{
+        .writer = &out_file_writer.interface,
+        .depth = 0,
+        .midline = false,
+    };
+    const writer = &code_writer;
 
     try writer.writeBlock(autogen_header);
-    // We can't import the everything module because it will re-introduce the same symbols we are exporting
-    //try writer.print("usingnamespace @import(\"everything.zig\");\n", .{});
     try writer.line("//--------------------------------------------------------------------------------");
     try writer.linef("// Section: Constants ({})", .{api.Constants.len});
     try writer.line("//--------------------------------------------------------------------------------");
@@ -800,14 +825,14 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
         while (it.next()) |entry| {
             const name = entry.key_ptr.*;
             try writer.linef(
-                "pub const {s} = switch(@import(\"{s}zig.zig\").arch) {{",
+                "pub const {f} = switch(@import(\"{s}zig.zig\").arch) {{",
                 .{ name, import_prefix_table[sdk_file.depth] },
             );
             var combined_arches: metadata.Architectures = .{ .filter = .{} };
             for (entry.value_ptr.getItemsConst()) |object| {
                 combined_arches = combined_arches.unionWith(.{ .filter = object.filter });
-                var buf: [40]u8 = undefined;
-                const def_prefix = buf[0..try formatArchesCase(object.filter, &buf)];
+                var prefix_buf: [40]u8 = undefined;
+                const def_prefix = prefix_buf[0..try formatArchesCase(object.filter, &prefix_buf)];
                 writer.depth += 1;
                 defer writer.depth -= 1;
                 // Enforce the type arches match the arches we filtered the type on.
@@ -863,7 +888,7 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
             if (entry.value_ptr.generated)
                 continue;
 
-            try writer.linef("pub const {s} = switch (@import(\"{s}zig.zig\").arch) {{", .{ name_pool, import_prefix_table[sdk_file.depth] });
+            try writer.linef("pub const {f} = switch (@import(\"{s}zig.zig\").arch) {{", .{ name_pool, import_prefix_table[sdk_file.depth] });
 
             var arches_handled: metadata.Architectures = .{ .filter = .{} };
 
@@ -872,19 +897,19 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
                 const node = arch_func_nodes.items[@intFromEnum(node_index)];
 
                 arches_handled = arches_handled.unionWith(node.func.Architectures);
-                var buf: [40]u8 = undefined;
-                const case_prefix = buf[0..try formatArchesCase(node.func.Architectures.filter.?, &buf)];
+                var prefix_buf: [40]u8 = undefined;
+                const case_prefix = prefix_buf[0..try formatArchesCase(node.func.Architectures.filter.?, &prefix_buf)];
                 try writer.linef("{s}(struct {{", .{case_prefix});
                 try writer.line("");
                 try generateFunction(sdk_file, writer, .{ .dll = node.func.* });
                 try writer.line("");
-                try writer.linef("}}).{},", .{name_pool});
+                try writer.linef("}}).{f},", .{name_pool});
 
                 node_index = node.next orelse break;
             }
             if (arches_handled.filter != null) {
                 try writer.linef(
-                    "    else => |a| if (@import(\"builtin\").is_test) void else @compileError(\"function '{}' is not supported on architecture \" ++ @tagName(a)),",
+                    "    else => |a| if (@import(\"builtin\").is_test) void else @compileError(\"function '{f}' is not supported on architecture \" ++ @tagName(a)),",
                     .{name_pool},
                 );
             }
@@ -940,7 +965,7 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
                 // TODO: should I cache this mapping from api ref to api import path?
                 const api_path = try allocApiImportPathFromRef(api_upper.slice);
                 defer allocator.free(api_path);
-                try writer.linef("const {s} = @import(\"{s}{s}.zig\").{0s};", .{ import.name, sdk_file.getWin32DirImportPrefix(), api_path });
+                try writer.linef("const {f} = @import(\"{s}{s}.zig\").{0f};", .{ import.name, sdk_file.getWin32DirImportPrefix(), api_path });
             }
         }
         if (arch_specific_imports.count() > 0) {
@@ -948,17 +973,17 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
             var arch_imports_it = arch_specific_imports.iterator();
             while (arch_imports_it.next()) |arch_import_node| {
                 const name = arch_import_node.key_ptr.*;
-                try writer.linef("const {s} = switch(@import(\"{s}zig.zig\").arch) {{", .{ name, import_prefix_table[sdk_file.depth] });
+                try writer.linef("const {f} = switch(@import(\"{s}zig.zig\").arch) {{", .{ name, import_prefix_table[sdk_file.depth] });
                 var combined_arches: metadata.Architectures = .{ .filter = .{} };
                 for (arch_import_node.value_ptr.getItemsConst()) |object| {
                     combined_arches = combined_arches.unionWith(.{ .filter = object.filter });
-                    var buf: [40]u8 = undefined;
-                    const def_prefix = buf[0..try formatArchesCase(object.filter, &buf)];
+                    var prefix_buf: [40]u8 = undefined;
+                    const def_prefix = prefix_buf[0..try formatArchesCase(object.filter, &prefix_buf)];
                     const api_upper = object.obj;
                     // TODO: should I cache this mapping from api ref to api import path?
                     const api_path = try allocApiImportPathFromRef(api_upper.slice);
                     defer allocator.free(api_path);
-                    try writer.linef("    {s}@import(\"{s}{s}.zig\").{s},", .{ def_prefix, sdk_file.getWin32DirImportPrefix(), api_path, name });
+                    try writer.linef("    {s}@import(\"{s}{s}.zig\").{f},", .{ def_prefix, sdk_file.getWin32DirImportPrefix(), api_path, name });
                 }
                 if (combined_arches.filter != null) {
                     //try writer.line("    else => @compileError(\"unsupported on this arch\"),");
@@ -977,7 +1002,7 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
     if (sdk_file.tmp_func_ptr_workaround_list.items.len > 0) {
         try writer.line("    // The following '_ = <FuncPtrType>' lines are a workaround for https://github.com/ziglang/zig/issues/4476");
         for (sdk_file.tmp_func_ptr_workaround_list.items) |func_ptr_type| {
-            try writer.linef("    if (@hasDecl(@This(), \"{s}\")) {{ _ = {0s}; }}", .{func_ptr_type});
+            try writer.linef("    if (@hasDecl(@This(), \"{f}\")) {{ _ = {0f}; }}", .{func_ptr_type});
         }
         try writer.line("");
     }
@@ -1002,7 +1027,7 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
         while (it.next()) |notnull_api| {
             const name = notnull_api.key_ptr.*;
             if (sdk_file.extra_funcs_applied.get(name)) |_| {} else {
-                std.log.err("extra.txt api '{s}' function '{s}' was not applied", .{ sdk_file.json_name, name });
+                std.log.err("extra.txt api '{f}' function '{f}' was not applied", .{ sdk_file.json_name, name });
                 error_count += 1;
             }
         }
@@ -1017,7 +1042,7 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
         while (it.next()) |up_api| {
             const pool_name = up_api.key_ptr.*;
             if (sdk_file.extra_consts_applied.get(pool_name)) |_| {} else {
-                std.log.err("extra.txt api '{s}' constant '{s}' was not applied", .{ sdk_file.json_name, pool_name });
+                std.log.err("extra.txt api '{f}' constant '{f}' was not applied", .{ sdk_file.json_name, pool_name });
                 error_count += 1;
             }
         }
@@ -1026,6 +1051,8 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
             std.process.exit(0xff);
         }
     }
+
+    try out_file_writer.interface.flush();
 }
 
 // TODO: should I cache this mapping from api ref to api import path?
@@ -1055,19 +1082,19 @@ fn addTypeRefs(
 
 fn addTypeRefsNoFormatter(sdk_file: *SdkFile, arches: metadata.Architectures, type_ref: metadata.TypeRef) anyerror!void {
     switch (type_ref) {
-        .Native => |native| switch (native.Name) {
+        .native => |native| switch (native.Name) {
             .Guid => sdk_file.uses_guid = true,
             else => {},
         },
-        .ApiRef => |api_ref| {
+        .api_ref => |api_ref| {
             const name = getApiRefSubstitute(api_ref.Name, api_ref.Parents) orelse api_ref.Name;
             const api = try global_symbol_pool.add(api_ref.Api);
             try sdk_file.addApiImport(arches, name, api, api_ref.Parents);
         },
-        .PointerTo => |to| try addTypeRefsNoFormatter(sdk_file, arches, to.Child.*),
-        .Array => |a| try addTypeRefsNoFormatter(sdk_file, arches, a.Child.*),
-        .LPArray => |a| try addTypeRefsNoFormatter(sdk_file, arches, a.Child.*),
-        .MissingClrType => {},
+        .pointer_to => |to| try addTypeRefsNoFormatter(sdk_file, arches, to.Child.*),
+        .array => |a| try addTypeRefsNoFormatter(sdk_file, arches, a.Child.*),
+        .lp_array => |a| try addTypeRefsNoFormatter(sdk_file, arches, a.Child.*),
+        .missing_clr_type => {},
     }
 }
 
@@ -1240,18 +1267,18 @@ fn generateTypeRefRec(
     depth_context: DepthContext,
 ) anyerror!void {
     switch (self.type_ref) {
-        .Native => |native| {
+        .native => |native| {
             const zig_type = zigTypeFromTypeRefNative(native.Name, depth_context);
             try writer.writef("{s}", .{zig_type}, .{ .start = .any, .nl = false });
         },
-        .ApiRef => |api_ref| {
+        .api_ref => |api_ref| {
             const name = getApiRefSubstitute(api_ref.Name, api_ref.Parents) orelse api_ref.Name;
             if (isAnonymousTypeName(name)) {
                 const anon_types = self.options.anon_types orelse
                     jsonPanicMsg("missing anonymous type '{s}' (this scope does not have any anonymous types)!", .{name});
                 const name_pool = try global_symbol_pool.add(name);
                 const t = anon_types.types.get(name_pool) orelse
-                    jsonPanicMsg("missing anonymous type '{s}'!", .{name_pool});
+                    jsonPanicMsg("missing anonymous type '{f}'!", .{name_pool});
                 switch (t.Kind) {
                     .Struct => try generateStructOrUnionDef(sdk_file, writer, t, self.nested_context),
                     .Union => try generateStructOrUnionDef(sdk_file, writer, t, self.nested_context),
@@ -1332,7 +1359,7 @@ fn generateTypeRefRec(
             //}
             try writer.writef("{s}", .{name}, .{ .start = .any, .nl = false });
         },
-        .PointerTo => |to| {
+        .pointer_to => |to| {
             var child_options = self.options.getChildOptions();
             if (self.options.reason == .var_decl and self.options.allowOptionalPtr()) {
                 try writer.write("?", .{ .start = .any, .nl = false });
@@ -1347,7 +1374,7 @@ fn generateTypeRefRec(
             }
             try generateTypeRefRec(sdk_file, writer, fmtTypeRef(to.Child.*, self.arches, child_options, self.nested_context), .child);
         },
-        .Array => |array| {
+        .array => |array| {
             const shape_size: u32 = init: {
                 if (array.Shape) |shape| break :init shape.Size;
                 // TODO: should we use size 1 here?
@@ -1356,7 +1383,7 @@ fn generateTypeRefRec(
             try writer.writef("[{}]", .{shape_size}, .{ .start = .any, .nl = false });
             try generateTypeRefRec(sdk_file, writer, fmtTypeRef(array.Child.*, self.arches, self.options, self.nested_context), .child);
         },
-        .LPArray => |array| {
+        .lp_array => |array| {
             if (self.options.optional) {
                 try writer.write("?", .{ .start = .any, .nl = false });
             }
@@ -1381,7 +1408,7 @@ fn generateTypeRefRec(
                 try generateTypeRefRec(sdk_file, writer, fmtTypeRef(array.Child.*, self.arches, self.options.getChildOptions(), self.nested_context), .array);
             }
         },
-        .MissingClrType => |t| try writer.writef(
+        .missing_clr_type => |t| try writer.writef(
             "*struct{{comment: []const u8 = \"MissingClrType {s}.{s}\"}}",
             .{ t.Name, t.Namespace },
             .{ .start = .any, .nl = false },
@@ -1422,7 +1449,7 @@ fn zigTypeFromTypeRefNative(
 
 fn isByteOrCharOrUInt16Type(type_ref: metadata.TypeRef) bool {
     return switch (type_ref) {
-        .Native => |t| switch (t.Name) {
+        .native => |t| switch (t.Name) {
             .Byte, .Char, .UInt16 => true,
             else => false,
         },
@@ -1437,18 +1464,11 @@ const ConstValueFormatter = struct {
     value_type: metadata.ValueType,
     value: std.json.Value,
     sdk_file: *SdkFile,
-    pub fn format(
-        self: @This(),
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
         if (self.value_type == .String) {
             switch (self.value) {
                 .null => try writer.writeAll("null"),
-                .string => |s| try writer.print("\"{}\"", .{std.zig.fmtEscapes(s)}),
+                .string => |s| try writer.print("\"{f}\"", .{std.zig.fmtString(s)}),
                 else => std.debug.panic("uhandled type '{s}'", .{@tagName(self.value)}),
             }
             return;
@@ -1474,7 +1494,7 @@ const ConstValueFormatter = struct {
                 else => {},
             }
         }
-        try writer.print("@as({s}, {})", .{ zig_type, fmtJson(self.value) });
+        try writer.print("@as({s}, {f})", .{ zig_type, fmtJson(self.value) });
     }
 };
 
@@ -1509,15 +1529,15 @@ fn generateConstant(sdk_file: *SdkFile, writer: *CodeWriter, constant: metadata.
 
     const zig_type_formatter = try addTypeRefs(sdk_file, .{}, constant.Type, options, null);
 
-    if (constant.Type == .Native) {
+    if (constant.Type == .native) {
         jsonEnforce(constant.ValueType != .PropertyKey);
-        if (constant.Type.Native.Name == .Guid) {
-            try writer.linef("pub const {s} = Guid.initString({});", .{
+        if (constant.Type.native.Name == .Guid) {
+            try writer.linef("pub const {f} = Guid.initString({f});", .{
                 name_pool,
                 fmtConstValue(constant.ValueType, constant.Value, sdk_file),
             });
         } else {
-            try writer.linef("pub const {s} = {};", .{
+            try writer.linef("pub const {f} = {f};", .{
                 name_pool,
                 fmtConstValue(constant.ValueType, constant.Value, sdk_file),
             });
@@ -1526,22 +1546,22 @@ fn generateConstant(sdk_file: *SdkFile, writer: *CodeWriter, constant: metadata.
         if (constant.ValueType == .PropertyKey) {
             const value_obj = switch (constant.Value) {
                 .object => |obj| obj,
-                else => jsonPanicMsg("expected PropertyKey to be an object but got: {s}", .{fmtJson(constant.Value)}),
+                else => jsonPanicMsg("expected PropertyKey to be an object but got: {f}", .{fmtJson(constant.Value)}),
             };
             try jsonObjEnforceKnownFieldsOnly(value_obj, &[_][]const u8{ "Fmtid", "Pid" }, sdk_file);
             const fmtid = (try jsonObjGetRequired(value_obj, "Fmtid", sdk_file)).string;
             const pid = (try jsonObjGetRequired(value_obj, "Pid", sdk_file)).integer;
-            try writer.writef("pub const {s} = ", .{name_pool}, .{ .nl = false });
+            try writer.writef("pub const {f} = ", .{name_pool}, .{ .nl = false });
             try generateTypeRef(sdk_file, writer, zig_type_formatter);
             sdk_file.uses_guid = true;
             try writer.writef(" {{ .fmtid = Guid.initString(\"{s}\"), .pid = {} }};", .{ fmtid, pid }, .{ .start = .mid });
         } else {
-            try writer.writef("pub const {s} = @import(\"{s}zig.zig\").typedConst(", .{
+            try writer.writef("pub const {f} = @import(\"{s}zig.zig\").typedConst(", .{
                 name_pool,
                 sdk_file.getWin32DirImportPrefix(),
             }, .{ .nl = false });
             try generateTypeRef(sdk_file, writer, zig_type_formatter);
-            try writer.writef(", {});", .{
+            try writer.writef(", {f});", .{
                 fmtConstValue(constant.ValueType, constant.Value, sdk_file),
             }, .{ .start = .mid });
         }
@@ -1561,7 +1581,7 @@ const also_usable_type_api_map = std.StaticStringMap([]const u8).initComptime(.{
 const Depth = u3;
 
 const CodeWriter = struct {
-    writer: BufferedWriter.Writer,
+    writer: *std.io.Writer,
     depth: u4,
     midline: bool,
 
@@ -1576,7 +1596,7 @@ const CodeWriter = struct {
         start: enum { line, any, mid } = .line,
         nl: bool = true,
     };
-    pub fn writef(self: *CodeWriter, comptime fmt: []const u8, args: anytype, comptime opt: LineOpt) !void {
+    pub fn writef(self: *CodeWriter, comptime fmt: []const u8, args: anytype, opt: LineOpt) !void {
         std.debug.assert(null == std.mem.indexOf(u8, fmt, "\n"));
         const do_indent = blk: {
             switch (opt.start) {
@@ -1599,10 +1619,11 @@ const CodeWriter = struct {
             self.midline = true;
         }
         if (@typeInfo(@TypeOf(args)).@"struct".fields.len == 0) {
-            try self.writer.writeAll(fmt ++ (if (opt.nl) "\n" else ""));
+            try self.writer.writeAll(fmt);
         } else {
-            try self.writer.print(fmt ++ (if (opt.nl) "\n" else ""), args);
+            try self.writer.print(fmt, args);
         }
+        if (opt.nl) try self.writer.writeByte('\n');
         self.midline = !opt.nl;
     }
 
@@ -1657,8 +1678,8 @@ fn generateType(
                 jsonPanicMsg("not impl", .{});
             const clsid_pool = try global_symbol_pool.addFormatted("CLSID_{s}", .{t.Name});
             sdk_file.uses_guid = true;
-            try writer.linef("const {s}_Value = Guid.initString(\"{s}\");", .{ clsid_pool, class_id.Guid });
-            try writer.linef("pub const {s} = &{0s}_Value;", .{clsid_pool});
+            try writer.linef("const {f}_Value = Guid.initString(\"{s}\");", .{ clsid_pool, class_id.Guid });
+            try writer.linef("pub const {f} = &{0f}_Value;", .{clsid_pool});
             try sdk_file.const_exports.append(clsid_pool);
             return;
         },
@@ -1686,7 +1707,7 @@ fn generateType(
     } else if (t.Architectures.filter) |filter| {
         try addArchSpecific(metadata.Type, arch_specific, pool_name, filter, t);
     } else {
-        const def_prefix = try std.fmt.allocPrint(allocator, "pub const {p} = ", .{std.zig.fmtId(t.Name)});
+        const def_prefix = try std.fmt.allocPrint(allocator, "pub const {f} = ", .{std.zig.fmtId(t.Name)});
         defer allocator.free(def_prefix);
         try generateTypeDefinition(sdk_file, writer, t, enum_alias_conflicts, pool_name, def_prefix, ";");
     }
@@ -1722,16 +1743,16 @@ fn generateTypeDefinition(
                 // verify the definition is what we expect, if not, we might be able to remove out workaround
                 //
                 const child_generic = switch (typedef.Def) {
-                    .PointerTo => |to| to.Child,
+                    .pointer_to => |to| to.Child,
                     else => jsonPanicMsg(
                         "definition of {s} has changed! (Def.Kind != PointerTo, it is {s})",
                         .{ t.Name, @tagName(typedef.Def) },
                     ),
                 };
                 const child_native = switch (child_generic.*) {
-                    .Native => |*n| n,
+                    .native => |*n| n,
                     else => jsonPanicMsg(
-                        "definition of {s} has changed! (Def.Child.Kind != Native, it is {s})",
+                        "definition of {f} has changed! (Def.Child.Kind != Native, it is {s})",
                         .{ pool_name, @tagName(child_generic.*) },
                     ),
                 };
@@ -1755,7 +1776,7 @@ fn generateTypeDefinition(
                 if (also_usable_type_api_map.get(also_usable_for)) |api| {
                     const api_pool = try global_symbol_pool.add(api);
                     try sdk_file.addApiImport(t.Architectures, also_usable_for, api_pool, &.{});
-                    try writer.linef("//TODO: type '{s}' is \"AlsoUsableFor\" '{s}' which means this type is implicitly", .{ pool_name, also_usable_for });
+                    try writer.linef("//TODO: type '{f}' is \"AlsoUsableFor\" '{s}' which means this type is implicitly", .{ pool_name, also_usable_for });
                     try writer.linef("//      convertible to '{s}' but not the other way around.  I don't know how to do this", .{also_usable_for});
                     try writer.line("//      in Zig so for now I'm just defining it as an alias");
                     try writer.linef("{s}{s}{s}", .{ def_prefix, also_usable_for, def_suffix });
@@ -1799,7 +1820,7 @@ fn generateTypeDefinition(
             if (funcPtrHasDependencyLoop(pool_name.slice)) {
                 try writer.line("// TODO: this function pointer causes dependency loop problems, so it's stubbed out");
                 try writer.linef(
-                    "{s}*const fn() callconv(@import(\"std\").os.windows.WINAPI) void{s}",
+                    "{s}*const fn() callconv(.winapi) void{s}",
                     .{ def_prefix, def_suffix },
                 );
                 return;
@@ -1942,10 +1963,7 @@ fn generateStructOrUnionDef(
                 jsonPanicMsg("not impl", .{});
             try anon_types.types.put(pool_name, nested_type.*);
         } else {
-            // TODO: I don't know why this isn't working!!!
-            //const def_prefix = try std.fmt.allocPrint(allocator, "pub const {p} = ", .{std.zig.fmtId(pool_name)});
-            //defer allocator.free(def_prefix);
-            try writer.writef("pub const {s} = ", .{pool_name}, .{ .nl = false });
+            try writer.writef("pub const {f} = ", .{pool_name}, .{ .nl = false });
             switch (nested_type.Kind) {
                 .Union => try generateStructOrUnionDef(sdk_file, writer, nested_type.*, this_nested_context),
                 .Struct => try generateStructOrUnionDef(sdk_file, writer, nested_type.*, this_nested_context),
@@ -1977,7 +1995,7 @@ fn generateStructOrUnionDef(
                 try writer.line("/// Deprecated");
             }
             const field_type_formatter = try addTypeRefs(sdk_file, t.Architectures, field.Type, field_options, this_nested_context);
-            try writer.writef("{p}: ", .{std.zig.fmtId(field.Name)}, .{ .nl = false });
+            try writer.writef("{f}: ", .{std.zig.fmtId(field.Name)}, .{ .nl = false });
             try generateTypeRef(sdk_file, writer, field_type_formatter);
             if (container.PackingSize >= 1) {
                 try writer.writef(" align({})", .{container.PackingSize}, .{ .start = .mid, .nl = false });
@@ -2159,7 +2177,7 @@ const EnumValue = struct {
                 if (std.mem.eql(u8, s, "9223372036854775808"))
                     return .{ .flag = 63 }; // TODO: verify this is not off-by-one
                 std.debug.panic(
-                    "todo: handle enum flag value json number string '{s}' ('{s}' '{s}')",
+                    "todo: handle enum flag value json number string '{s}' ('{f}' '{s}')",
                     .{ s, self.pool_name, self.short_name },
                 );
             },
@@ -2257,7 +2275,7 @@ fn generateEnum(
     } else if (!type_enum.Flags) {
         for (values) |val| {
             if (val.conflict_index == null) {
-                try writer.linef("    {p} = {},", .{ std.zig.fmtId(val.short_name), fmtJson(val.value) });
+                try writer.linef("    {f} = {f},", .{ std.zig.fmtId(val.short_name), fmtJson(val.value) });
             }
         }
         if (non_exhaustive_enums.get(pool_name.slice)) |_| {
@@ -2265,19 +2283,22 @@ fn generateEnum(
         }
         for (values) |val| {
             if (val.conflict_index) |conflict_index| {
-                try writer.linef("    pub const {p} = .{p};", .{ std.zig.fmtId(val.short_name), std.zig.fmtId(values[conflict_index].short_name) });
+                try writer.linef(
+                    "    pub const {f} = .{f};",
+                    .{ std.zig.fmtId(val.short_name), std.zig.fmtId(values[conflict_index].short_name) },
+                );
             }
         }
         if (non_exhaustive_enums.get(pool_name.slice)) |_| {
             writer.depth += 1;
             defer writer.depth -= 1;
-            try writer.linef("pub fn tagName(self: {s}) ?[:0]const u8 {{", .{pool_name});
+            try writer.linef("pub fn tagName(self: {f}) ?[:0]const u8 {{", .{pool_name});
             try writer.line("    return switch (self) {");
             for (values) |val| {
                 if (val.conflict_index) |_| continue;
-                try writer.linef("        .{p} => \"{}\",", .{
+                try writer.linef("        .{f} => \"{f}\",", .{
                     std.zig.fmtId(val.short_name),
-                    std.zig.fmtEscapes(val.short_name),
+                    std.zig.fmtString(val.short_name),
                 });
             }
             try writer.line("        else => null,");
@@ -2293,16 +2314,13 @@ fn generateEnum(
                 try writer.line("// Instead, we use FormatMessage to access a string for each error.");
             }
             try writer.line("pub fn format(");
-            try writer.linef("    self: {s},", .{pool_name});
-            try writer.line("    comptime fmt: []const u8,");
-            try writer.line("    options: @import(\"std\").fmt.FormatOptions,");
-            try writer.line("    writer: anytype,");
-            try writer.line(") !void {");
+            try writer.linef("    self: {f},", .{pool_name});
+            try writer.line("    writer: *@import(\"std\").io.Writer,");
+            try writer.line(") @import(\"std\").io.Writer.Error!void {");
             if (is_win32_error) {
-                try writer.line("    try @import(\"zig.zig\").fmtError(@intFromEnum(self)).format(fmt, options, writer);");
+                // TODO: What calls this with the `s` format string vs `` (need to call formatWithCode)?
+                try writer.line("    try @import(\"zig.zig\").fmtError(@intFromEnum(self)).format(writer);");
             } else {
-                try writer.line("    _ = fmt;");
-                try writer.line("    _ = options;");
                 try writer.line("    try writer.print(\"{s}({})\", .{self.value.tagName() orelse \"?\", @intFromEnum(self.value)});");
             }
             try writer.line("}");
@@ -2334,7 +2352,7 @@ fn generateEnum(
                 try writer.linef("    _{}: u1 = 0,", .{i});
                 continue;
             };
-            try writer.linef("    {p}: u1 = 0,", .{std.zig.fmtId(flag.short_name)});
+            try writer.linef("    {f}: u1 = 0,", .{std.zig.fmtId(flag.short_name)});
         }
         for (flag_map[bit_count..]) |maybe_flag| {
             if (maybe_flag) |_|
@@ -2347,7 +2365,7 @@ fn generateEnum(
                 .zero => {},
                 .flag => |index| {
                     if (val.conflict_index) |conflict_index| {
-                        try writer.linef("    // {p} (bit index {}) conflicts with {p}", .{
+                        try writer.linef("    // {f} (bit index {}) conflicts with {f}", .{
                             std.zig.fmtId(val.short_name),
                             index,
                             std.zig.fmtId(values[conflict_index].short_name),
@@ -2370,7 +2388,7 @@ fn generateEnum(
         return;
     }
     if (suppress_enum_aliases.get(pool_name.slice)) |_| {
-        try writer.linef("// TODO: enum '{}' has known issues with its value aliases", .{pool_name});
+        try writer.linef("// TODO: enum '{f}' has known issues with its value aliases", .{pool_name});
         return;
     }
 
@@ -2378,10 +2396,10 @@ fn generateEnum(
     var alias_count: u32 = 0;
     for (values) |val| {
         if (enum_alias_conflicts.get(val.pool_name)) |existing| {
-            std.debug.print("error: enum value alias '{}' is defined by 2 enum types.\n", .{val.pool_name});
+            std.debug.print("error: enum value alias '{f}' is defined by 2 enum types.\n", .{val.pool_name});
             std.debug.print("       add one of the following lines to the suppress_enum_aliases list:\n", .{});
-            std.debug.print("    .{{ \"{}\", .{{}} }},\n", .{existing});
-            std.debug.print("    .{{ \"{}\", .{{}} }},\n", .{pool_name});
+            std.debug.print("    .{{ \"{f}\", .{{}} }},\n", .{existing});
+            std.debug.print("    .{{ \"{f}\", .{{}} }},\n", .{pool_name});
             std.process.exit(0xff);
         }
         if (val.no_alias) {
@@ -2392,10 +2410,10 @@ fn generateEnum(
         try sdk_file.const_exports.append(val.pool_name);
         const target_short_name = if (val.conflict_index) |i| values[i].short_name else val.short_name;
         if (type_enum.Flags) switch (val.flagsValue()) {
-            .zero => try writer.linef("pub const {} = {}{{ }};", .{ val.pool_name, pool_name }),
-            .flag => try writer.linef("pub const {} = {}{{ .{p} = 1 }};", .{ val.pool_name, pool_name, std.zig.fmtId(target_short_name) }),
+            .zero => try writer.linef("pub const {f} = {f}{{ }};", .{ val.pool_name, pool_name }),
+            .flag => try writer.linef("pub const {f} = {f}{{ .{f} = 1 }};", .{ val.pool_name, pool_name, std.zig.fmtId(target_short_name) }),
             .mask => |mask| {
-                try writer.linef("pub const {} = {}{{", .{ val.pool_name, pool_name });
+                try writer.linef("pub const {f} = {f}{{", .{ val.pool_name, pool_name });
                 var mask_left = mask;
                 var index: u6 = 0;
                 while (true) : (index += 1) {
@@ -2403,7 +2421,7 @@ fn generateEnum(
                     if (0 != (next_flag_bit & mask)) {
                         if (flag_map[index]) |flag| {
                             const flag_target_short_name = if (flag.conflict_index) |i| values[i].short_name else flag.short_name;
-                            try writer.linef("    .{p} = 1,", .{std.zig.fmtId(flag_target_short_name)});
+                            try writer.linef("    .{f} = 1,", .{std.zig.fmtId(flag_target_short_name)});
                         } else {
                             try writer.linef("    ._{} = 1,", .{index});
                         }
@@ -2414,7 +2432,7 @@ fn generateEnum(
                 try writer.line("};");
             },
         } else {
-            try writer.linef("pub const {} = {}.{p};", .{ val.pool_name, pool_name, std.zig.fmtId(target_short_name) });
+            try writer.linef("pub const {f} = {f}.{f};", .{ val.pool_name, pool_name, std.zig.fmtId(target_short_name) });
         }
     }
 }
@@ -2450,8 +2468,8 @@ fn generateCom(
     const iid_pool = try global_symbol_pool.addFormatted("IID_{s}", .{com_pool_name.slice});
     if (type_com.Guid) |guid| {
         sdk_file.uses_guid = true;
-        try writer.linef("const {s}_Value = Guid.initString(\"{s}\");", .{ iid_pool, guid });
-        try writer.linef("pub const {s} = &{0s}_Value;", .{iid_pool});
+        try writer.linef("const {f}_Value = Guid.initString(\"{s}\");", .{ iid_pool, guid });
+        try writer.linef("pub const {f} = &{0f}_Value;", .{iid_pool});
         try sdk_file.const_exports.append(iid_pool);
     }
 
@@ -2485,7 +2503,7 @@ fn generateCom(
             switch (state) {
                 .unique => {
                     if (maybe_overload_suffixes) |_| fatal(
-                        "api '{s}' COM type '{s}' method '{s}' has a unique name but also entries in ComOverloads.txt?",
+                        "api '{f}' COM type '{f}' method '{s}' has a unique name but also entries in ComOverloads.txt?",
                         .{ sdk_file.json_name, com_pool_name, method.Name },
                     );
                 },
@@ -2633,7 +2651,7 @@ fn generateComMethods(
             "{s}{s}",
             .{ method.Name, suffix },
         );
-        try writer.writef("{}", .{
+        try writer.writef("{f}", .{
             fmtComMethodId(method_name, sdk_file.method_conflict_map),
         }, .{ .start = .mid, .nl = false });
         try writer.writef("(self: *const {s}", .{com_type_name}, .{ .start = .mid, .nl = false });
@@ -2647,7 +2665,7 @@ fn generateComMethods(
                 _ = bytes_param_index; // NOTE: can't print this because we are currently inline
                 //try writer.linef("// TODO: what to do with BytesParamIndex {}?", .{bytes_param_index});
             }
-            try writer.writef(", {s}: ", .{fmtParamId(param.Name, sdk_file.param_conflict_map)}, .{ .start = .mid, .nl = false });
+            try writer.writef(", {f}: ", .{fmtParamId(param.Name, sdk_file.param_conflict_map)}, .{ .start = .mid, .nl = false });
             try generateTypeRef(sdk_file, writer, param_type_formatter);
         }
         // NOTE: don't need to call addTypeRefs because it was already called in generateFunction above
@@ -2668,12 +2686,12 @@ fn generateComMethods(
         try writer.write(" {", .{ .start = .mid });
         try writer.write("        return ", .{ .nl = false });
         try writer.writef(
-            "self.vtable.{}(self",
+            "self.vtable.{f}(self",
             .{fmtComMethodId(method_name, sdk_file.method_conflict_map)},
             .{ .start = .mid, .nl = false },
         );
         for (method.Params) |*param| {
-            try writer.writef(", {s}", .{fmtParamId(param.Name, sdk_file.param_conflict_map)}, .{ .start = .mid, .nl = false });
+            try writer.writef(", {f}", .{fmtParamId(param.Name, sdk_file.param_conflict_map)}, .{ .start = .mid, .nl = false });
         }
         try writer.write(");", .{ .start = .any });
         try writer.line("    }");
@@ -2749,22 +2767,6 @@ const dll_funcs_with_issues = std.StaticStringMap(void).initComptime(.{
 });
 
 const ArchCaseContext = enum { outside_arch_case, inside_arch_case };
-
-const ConflictSuffix = struct {
-    conflict_count: u8,
-    pub fn format(
-        self: ConflictSuffix,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
-        if (self.conflict_count > 0) {
-            try writer.print("{}", .{self.conflict_count});
-        }
-    }
-};
 
 const ParamModifierSet = struct {
     const max_params = 30;
@@ -2876,7 +2878,7 @@ fn getFuncModifiers(
             if (std.mem.eql(u8, name.slice, "Return")) @panic("todo");
 
             const index = findParam(params, name.slice) orelse std.debug.panic(
-                "function '{s}' from extra.txt does not have a parameter named '{s}'",
+                "function '{f}' from extra.txt does not have a parameter named '{f}'",
                 .{ config_name, name },
             );
             set.params[index] = entry.value_ptr.*;
@@ -2928,12 +2930,12 @@ fn generateFunction(
             // the .lib files using lowercase since that's what mingw uses.
             // note the casing only matters on case-sensitive filesystems
             try writer.linef(
-                "pub extern \"{s}\" fn {}(",
-                .{ fmtLower(dll.DllImport, 100), std.zig.fmtId(dll.Name) },
+                "pub extern \"{f}\" fn {f}(",
+                .{ fmtLower(dll.DllImport), std.zig.fmtId(dll.Name) },
             );
         },
         .com => |com| {
-            try writer.linef("{}: *const fn(", .{std.zig.fmtId(com.zig_name)});
+            try writer.linef("{f}: *const fn(", .{std.zig.fmtId(com.zig_name)});
             try writer.linef("    self: *const {s},", .{com.type_name});
         },
         .ptr => |ptr| try writer.linef("{s}*const fn(", .{ptr.def_prefix}),
@@ -2941,7 +2943,7 @@ fn generateFunction(
 
     try generateParams(sdk_file, writer, arches, modifier_set, params);
 
-    try writer.writef(") callconv(@import(\"std\").os.windows.WINAPI) ", .{}, .{ .nl = false });
+    try writer.writef(") callconv(.winapi) ", .{}, .{ .nl = false });
     if (attrs.DoesNotReturn) {
         try writer.write("noreturn", .{ .start = .mid, .nl = false });
     } else {
@@ -2972,7 +2974,7 @@ fn generateParams(
         if (param_options.optional_bytes_param_index) |bytes_param_index| {
             try writer.linef("    // TODO: what to do with BytesParamIndex {}?", .{bytes_param_index});
         }
-        try writer.writef("    {p}: ", .{std.zig.fmtId(param.Name)}, .{ .nl = false });
+        try writer.writef("    {f}: ", .{std.zig.fmtId(param.Name)}, .{ .nl = false });
         try generateTypeRef(sdk_file, writer, param_type_formatter);
         try writer.write(",", .{ .start = .mid });
     }
@@ -2994,18 +2996,17 @@ fn generateUnicodeAliases(sdk_file: *SdkFile, writer: *CodeWriter, unicode_alias
 }
 
 pub fn formatArchesCase(filter: metadata.Architectures.Filter, buf: []u8) !usize {
-    var fbs = std.io.fixedBufferStream(buf);
-    const arch_writer = fbs.writer();
+    var writer: std.io.Writer = .fixed(buf);
     var case_prefix: []const u8 = "";
     inline for (std.meta.fields(metadata.Architectures.Filter)) |arch_field| {
         const enabled = @field(filter, arch_field.name);
         if (enabled) {
-            try arch_writer.print("{s}.{s}", .{ case_prefix, arch_field.name });
+            try writer.print("{s}.{s}", .{ case_prefix, arch_field.name });
             case_prefix = ", ";
         }
     }
-    try arch_writer.writeAll(" => ");
-    return fbs.pos;
+    try writer.writeAll(" => ");
+    return writer.end;
 }
 
 const ArchCount = 3;
@@ -3045,7 +3046,7 @@ pub fn jsonObjEnforceKnownFieldsOnly(
                 continue :fieldLoop;
         }
         std.log.err(
-            "{s}: JSON object has unknown field '{s}', expected one of: {}\n",
+            "{s}: JSON object has unknown field '{s}', expected one of: {f}\n",
             .{ sdk_file.json_basename, kv.key_ptr.*, common.formatSliceT([]const u8, "s", known_fields) },
         );
         jsonPanic();
@@ -3059,7 +3060,10 @@ pub fn jsonObjGetRequired(
 ) !std.json.Value {
     return map.get(field) orelse {
         // TODO: print file location?
-        std.log.err("{s}: json object is missing '{s}' field: {}\n", .{ sdk_file.json_basename, field, fmtJson(map) });
+        std.log.err(
+            "{s}: json object is missing '{s}' field: {f}\n",
+            .{ sdk_file.json_basename, field, fmtJson(map) },
+        );
         jsonPanic();
     };
 }
@@ -3191,22 +3195,15 @@ pub const FmtId = struct {
     s: []const u8,
     kind: enum { param, com_method },
     avoid_map: std.StaticStringMap(void),
-    pub fn format(
-        self: @This(),
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
         if (self.avoid_map.get(self.s)) |_| {
-            const prefix: []const u8 = switch (self.kind) {
+            const prefix = switch (self.kind) {
                 .param => "_param_",
                 .com_method => "_method_",
             };
             try writer.print("{s}{s}", .{ prefix, self.s });
         } else {
-            try writer.print("{}", .{std.zig.fmtId(self.s)});
+            try writer.print("{f}", .{std.zig.fmtId(self.s)});
         }
     }
 };
@@ -3238,27 +3235,17 @@ pub fn fmtComMethodId(s: []const u8, avoid_map: std.StaticStringMap(void)) FmtId
     return FmtId{ .s = s, .kind = .com_method, .avoid_map = avoid_map };
 }
 
-pub fn FmtLower(comptime buffer_size: comptime_int) type {
-    return struct {
-        s: []const u8,
-        pub fn format(
-            self: @This(),
-            comptime fmt: []const u8,
-            options: std.fmt.FormatOptions,
-            writer: anytype,
-        ) !void {
-            _ = fmt;
-            _ = options;
-            var buffered = std.io.BufferedWriter(buffer_size, @TypeOf(writer)){ .unbuffered_writer = writer };
-            for (self.s) |c| {
-                const lower = [_]u8{std.ascii.toLower(c)};
-                try buffered.writer().writeAll(&lower);
-            }
-            try buffered.flush();
+const FmtLower = struct {
+    s: []const u8,
+    pub fn format(self: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
+        for (self.s) |c| {
+            const lower = [_]u8{std.ascii.toLower(c)};
+            try writer.writeAll(&lower);
         }
-    };
-}
-pub fn fmtLower(s: []const u8, comptime buffer_size: comptime_int) FmtLower(buffer_size) {
+    }
+};
+
+pub fn fmtLower(s: []const u8) FmtLower {
     return .{ .s = s };
 }
 

--- a/src/genzigexports.zig
+++ b/src/genzigexports.zig
@@ -21,11 +21,15 @@ pub fn main() !void {
     const out_file = try std.fs.cwd().createFile(out_file_path, .{});
     defer out_file.close();
 
-    var bw = std.io.bufferedWriter(out_file.writer());
-    try generate(bw.writer().any());
-    try bw.flush();
+    var buf: [4096]u8 = undefined;
+    var out_file_writer = out_file.writer(&buf);
+    var w = &out_file_writer.interface;
+
+    try generate(w);
+    try w.flush();
 }
-fn generate(writer: std.io.AnyWriter) !void {
+
+fn generate(writer: *std.io.Writer) !void {
     try writer.writeAll("pub const Kind = enum { constant, type, function };\n");
     try writer.writeAll("pub const Decl = struct { kind: Kind, name: []const u8};\n");
     try writer.writeAll("pub const declarations = [_]Decl{\n");

--- a/src/metadata.zig
+++ b/src/metadata.zig
@@ -467,20 +467,20 @@ const TargetKind = enum {
 };
 
 const TypeRefKind = enum {
-    Native,
-    ApiRef,
-    PointerTo,
-    Array,
-    LPArray,
-    MissingClrType,
+    native,
+    api_ref,
+    pointer_to,
+    array,
+    lp_array,
+    missing_clr_type,
 };
 const type_ref_kinds = std.StaticStringMap(TypeRefKind).initComptime(.{
-    .{ "Native", .Native },
-    .{ "ApiRef", .ApiRef },
-    .{ "PointerTo", .PointerTo },
-    .{ "Array", .Array },
-    .{ "LPArray", .LPArray },
-    .{ "MissingClrType", .MissingClrType },
+    .{ "Native", .native },
+    .{ "ApiRef", .api_ref },
+    .{ "PointerTo", .pointer_to },
+    .{ "Array", .array },
+    .{ "LPArray", .lp_array },
+    .{ "MissingClrType", .missing_clr_type },
 });
 
 const Native = struct {
@@ -523,12 +523,12 @@ const MissingClrType = struct {
 };
 
 pub const TypeRef = union(TypeRefKind) {
-    Native: Native,
-    ApiRef: ApiRef,
-    PointerTo: PointerTo,
-    Array: Array,
-    LPArray: LPArray,
-    MissingClrType: MissingClrType,
+    native: Native,
+    api_ref: ApiRef,
+    pointer_to: PointerTo,
+    array: Array,
+    lp_array: LPArray,
+    missing_clr_type: MissingClrType,
 
     pub fn jsonParse(
         allocator: std.mem.Allocator,
@@ -537,23 +537,23 @@ pub const TypeRef = union(TypeRefKind) {
     ) std.json.ParseError(@TypeOf(source.*))!TypeRef {
         if (.object_begin != try source.next()) return error.UnexpectedToken;
         switch (try jsonParseUnionKind(TypeRefKind, "TypeRef", source, type_ref_kinds)) {
-            .Native => return .{
-                .Native = try parseUnionObject(Native, allocator, source, options),
+            .native => return .{
+                .native = try parseUnionObject(Native, allocator, source, options),
             },
-            .ApiRef => return .{
-                .ApiRef = try parseUnionObject(ApiRef, allocator, source, options),
+            .api_ref => return .{
+                .api_ref = try parseUnionObject(ApiRef, allocator, source, options),
             },
-            .PointerTo => return .{
-                .PointerTo = try parseUnionObject(PointerTo, allocator, source, options),
+            .pointer_to => return .{
+                .pointer_to = try parseUnionObject(PointerTo, allocator, source, options),
             },
-            .Array => return .{
-                .Array = try parseUnionObject(Array, allocator, source, options),
+            .array => return .{
+                .array = try parseUnionObject(Array, allocator, source, options),
             },
-            .LPArray => return .{
-                .LPArray = try parseUnionObject(LPArray, allocator, source, options),
+            .lp_array => return .{
+                .lp_array = try parseUnionObject(LPArray, allocator, source, options),
             },
-            .MissingClrType => return .{
-                .MissingClrType = try parseUnionObject(MissingClrType, allocator, source, options),
+            .missing_clr_type => return .{
+                .missing_clr_type = try parseUnionObject(MissingClrType, allocator, source, options),
             },
         }
     }

--- a/test/badcomoverload.zig
+++ b/test/badcomoverload.zig
@@ -1,8 +1,6 @@
-const win32 = struct {
-    usingnamespace @import("win32").graphics.direct2d;
-};
+const direct2d = @import("win32").graphics.direct2d;
 
 pub fn main() void {
-    var elem: *win32.ID2D1SvgElement = undefined;
+    var elem: *direct2d.ID2D1SvgElement = undefined;
     elem.GetAttributeValue(0, 0, 0);
 }

--- a/test/comoverload.zig
+++ b/test/comoverload.zig
@@ -1,18 +1,14 @@
 const std = @import("std");
-const WINAPI = std.os.windows.WINAPI;
-const win32 = struct {
-    usingnamespace @import("win32").foundation;
-    usingnamespace @import("win32").graphics.direct2d;
-    usingnamespace @import("win32").zig;
-};
+const win32 = @import("win32");
+const direct2d = win32.graphics.direct2d;
 
 fn GetAttributeValueString(
-    self: *const win32.ID2D1SvgElement,
+    self: *const direct2d.ID2D1SvgElement,
     name: ?[*:0]const u16,
-    @"type": win32.D2D1_SVG_ATTRIBUTE_STRING_TYPE,
+    @"type": direct2d.D2D1_SVG_ATTRIBUTE_STRING_TYPE,
     value: [*:0]u16,
     valueCount: u32,
-) callconv(WINAPI) win32.HRESULT {
+) callconv(.winapi) win32.foundation.HRESULT {
     _ = self;
     _ = name;
     _ = @"type";
@@ -22,15 +18,15 @@ fn GetAttributeValueString(
 }
 
 pub fn main() void {
-    var vtable: win32.ID2D1SvgElement.VTable = undefined;
+    var vtable: direct2d.ID2D1SvgElement.VTable = undefined;
     vtable.GetAttributeValueString = &GetAttributeValueString;
-    var element_instance: win32.ID2D1SvgElement = .{
+    var element_instance: direct2d.ID2D1SvgElement = .{
         .vtable = &vtable,
     };
     const element = &element_instance;
     var value_buf: [10:0]u16 = undefined;
     std.debug.assert(0 == element.GetAttributeValueString(
-        win32.L("Hello"),
+        win32.foundation.L("Hello"),
         .SVG,
         &value_buf,
         value_buf.len,


### PR DESCRIPTION
I started work on updating to the latest zig master branch changes:

- Fixes to handle Writergate: https://github.com/ziglang/zig/pull/24329
- Removed usages of `usingnamespace` in tests
- Build script fixups

This is currently blocked on https://github.com/ziglang/zig/issues/24468:

```zig
            // TODO: Compile error until https://github.com/ziglang/zig/issues/24468 is resolved
            //else => try std.json.stringify(self.value, .{}, writer),
            else => try writer.writeAll("TODO"),
```

Once that ticket is resolved, I can restore this code and verify everything works as expected.
