### PR TITLE
Update to 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,14 +5,6 @@ const Step = std.Build.Step;
 const CrossTarget = std.zig.CrossTarget;
 const buildcommon = @import("buildcommon.zig");
 
-comptime {
-    const required_zig = "0.14.0";
-    const v = std.SemanticVersion.parse(required_zig) catch unreachable;
-    if (builtin.zig_version.order(v) != .eq) @compileError(
-        "zig version " ++ required_zig ++ " is required to ensure zigwin32 output is always the same",
-    );
-}
-
 pub fn build(b: *Build) !void {
     const default_steps = "install diff test";
     b.default_step = b.step(
@@ -50,9 +42,11 @@ pub fn build(b: *Build) !void {
     const pass1_out_file = blk: {
         const pass1_exe = b.addExecutable(.{
             .name = "pass1",
-            .root_source_file = b.path("src/pass1.zig"),
-            .optimize = optimize,
-            .target = b.graph.host,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/pass1.zig"),
+                .optimize = optimize,
+                .target = b.graph.host,
+            }),
         });
 
         const run = b.addRunArtifact(pass1_exe);
@@ -66,8 +60,10 @@ pub fn build(b: *Build) !void {
     const zigexports = blk: {
         const exe = b.addExecutable(.{
             .name = "genzigexports",
-            .root_source_file = b.path("src/genzigexports.zig"),
-            .target = b.graph.host,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/genzigexports.zig"),
+                .target = b.graph.host,
+            }),
         });
         exe.root_module.addImport("win32_stub", b.createModule(.{
             .root_source_file = b.path("src/static/win32.zig"),
@@ -80,9 +76,11 @@ pub fn build(b: *Build) !void {
     const gen_out_dir = blk: {
         const exe = b.addExecutable(.{
             .name = "genzig",
-            .root_source_file = b.path("src/genzig.zig"),
-            .optimize = optimize,
-            .target = b.graph.host,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/genzig.zig"),
+                .optimize = optimize,
+                .target = b.graph.host,
+            }),
         });
         exe.root_module.addImport(
             "zigexports",
@@ -112,9 +110,11 @@ pub fn build(b: *Build) !void {
     {
         const diff_exe = b.addExecutable(.{
             .name = "diff",
-            .root_source_file = b.path("src/diff.zig"),
-            .target = b.graph.host,
-            .optimize = .Debug,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/diff.zig"),
+                .target = b.graph.host,
+                .optimize = .Debug,
+            }),
         });
         const diff = b.addRunArtifact(diff_exe);
         // fetches from zigwin32 github and also modifies the contents
@@ -133,9 +133,11 @@ pub fn build(b: *Build) !void {
 
     {
         const unittest = b.addTest(.{
-            .root_source_file = gen_out_dir.path(b, "win32.zig"),
-            .target = b.graph.host,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = gen_out_dir.path(b, "win32.zig"),
+                .target = b.graph.host,
+                .optimize = optimize,
+            }),
         });
         unittest.pie = true;
         unittest_step.dependOn(&unittest.step);
@@ -150,8 +152,10 @@ pub fn build(b: *Build) !void {
     {
         const exe = b.addExecutable(.{
             .name = "comoverload",
-            .root_source_file = b.path("test/comoverload.zig"),
-            .target = b.graph.host,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("test/comoverload.zig"),
+                .target = b.graph.host,
+            }),
         });
         exe.root_module.addImport("win32", win32);
         const run = b.addRunArtifact(exe);
@@ -197,10 +201,9 @@ const PrintLazyPath = struct {
     fn make(step: *Step, opt: std.Build.Step.MakeOptions) !void {
         _ = opt;
         const print: *PrintLazyPath = @fieldParentPtr("step", step);
-        try std.io.getStdOut().writer().print(
-            "{s}\n",
-            .{print.lazy_path.getPath(step.owner)},
-        );
+        const stdout = std.fs.File.stdout();
+        var writer = stdout.writer(&.{});
+        try writer.interface.print("{s}\n", .{print.lazy_path.getPath(step.owner)});
     }
 };
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zigwin32gen,
     .version = "0.0.0",
     .fingerprint = 0xab047bbd59488dae,
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0",
     .dependencies = .{
         .win32json = .{
             .url = "git+https://github.com/marlersoft/win32json#d1f6a1fba4a7714f65b9c8a2696e7530561366ef",

--- a/buildcommon.zig
+++ b/buildcommon.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 
 pub fn addExamples(
     b: *std.Build,
-    optimize: std.builtin.Mode,
+    optimize: std.builtin.OptimizeMode,
     win32: *std.Build.Module,
     examples: std.Build.LazyPath,
 ) void {
@@ -30,7 +30,7 @@ pub fn addExamples(
 fn addExample(
     b: *std.Build,
     arches: []const ?[]const u8,
-    optimize: std.builtin.Mode,
+    optimize: std.builtin.OptimizeMode,
     win32: *std.Build.Module,
     examples: std.Build.LazyPath,
     root: []const u8,
@@ -46,10 +46,12 @@ fn addExample(
         const target = b.resolveTargetQuery(target_query);
         const exe = b.addExecutable(.{
             .name = name,
-            .root_source_file = examples.path(b, basename),
-            .target = target,
-            .optimize = optimize,
-            .single_threaded = true,
+            .root_module = b.createModule(.{
+                .root_source_file = examples.path(b, basename),
+                .target = target,
+                .optimize = optimize,
+                .single_threaded = true,
+            }),
             .win32_manifest = if (subsystem == .Windows) examples.path(b, "win32.manifest") else null,
         });
         exe.subsystem = subsystem;

--- a/examples/basewin.zig
+++ b/examples/basewin.zig
@@ -1,74 +1,64 @@
 //! This example is ported from : https://github.com/microsoft/Windows-classic-samples/blob/master/Samples/Win7Samples/begin/LearnWin32/Direct2DCircle/cpp/basewin.h
 
-const WINAPI = @import("std").os.windows.WINAPI;
-const win32 = struct {
-    usingnamespace @import("win32").zig;
-    usingnamespace @import("win32").foundation;
-    usingnamespace @import("win32").system.system_services;
-    usingnamespace @import("win32").system.library_loader;
-    usingnamespace @import("win32").ui.windows_and_messaging;
-};
-const L = win32.L;
-const HWND = win32.HWND;
+const win32 = @import("win32");
+const foundation = win32.foundation;
+const ui_window = win32.ui.windows_and_messaging;
+const lib_loader = win32.system.library_loader;
+const windowlongptr = win32.windowlongptr;
 
-const windowlongptr = @import("win32").windowlongptr;
-
-// NOTE: can't do usingnamespace for menu_and_resources because it has conflicts with windows_and_messaging
-//       I think this particular one is a problem with win32metadata.
-//       NOTE: should Zig allow symbol conflicts so long as they are not referenced?
-const mnr = @import("win32").ui.menus_and_resources;
+const HWND = win32.foundation.HWND;
 
 pub fn BaseWindow(comptime DERIVED_TYPE: type) type {
     return struct {
-        fn WindowProc(hwnd: HWND, uMsg: u32, wParam: win32.WPARAM, lParam: win32.LPARAM) callconv(WINAPI) win32.LRESULT {
+        fn WindowProc(hwnd: HWND, uMsg: u32, wParam: win32.foundation.WPARAM, lParam: win32.foundation.LPARAM) callconv(.winapi) win32.foundation.LRESULT {
             var pThis: ?*DERIVED_TYPE = null;
-            if (uMsg == win32.WM_NCCREATE) {
-                const pCreate: *win32.CREATESTRUCT = @ptrFromInt(@as(usize, @bitCast(lParam)));
+            if (uMsg == ui_window.WM_NCCREATE) {
+                const pCreate: *ui_window.CREATESTRUCT = @ptrFromInt(@as(usize, @bitCast(lParam)));
                 pThis = @ptrCast(@alignCast(pCreate.lpCreateParams));
-                _ = windowlongptr.SetWindowLongPtr(hwnd, win32.GWL_USERDATA, @bitCast(@intFromPtr(pThis)));
+                _ = windowlongptr.SetWindowLongPtr(hwnd, ui_window.GWL_USERDATA, @bitCast(@intFromPtr(pThis)));
                 pThis.?.base.m_hwnd = hwnd;
             } else {
-                //pThis = @intToPtr(?*DERIVED_TYPE, @bitCast(usize, windowlongptr.GetWindowLongPtr(hwnd, win32.GWL_USERDATA)));
-                pThis = @ptrFromInt(@as(usize, @bitCast(windowlongptr.GetWindowLongPtr(hwnd, win32.GWL_USERDATA))));
+                //pThis = @intToPtr(?*DERIVED_TYPE, @bitCast(usize, windowlongptr.GetWindowLongPtr(hwnd, ui_window.GWL_USERDATA)));
+                pThis = @ptrFromInt(@as(usize, @bitCast(windowlongptr.GetWindowLongPtr(hwnd, ui_window.GWL_USERDATA))));
             }
             if (pThis) |this| {
                 return this.HandleMessage(uMsg, wParam, lParam);
             } else {
-                return win32.DefWindowProc(hwnd, uMsg, wParam, lParam);
+                return ui_window.DefWindowProc(hwnd, uMsg, wParam, lParam);
             }
         }
 
         pub fn Create(
             self: *@This(),
             lpWindowName: [*:0]const u16,
-            dwStyle: win32.WINDOW_STYLE,
+            dwStyle: ui_window.WINDOW_STYLE,
             options: struct {
-                dwExStyle: win32.WINDOW_EX_STYLE = .{},
-                x: i32 = win32.CW_USEDEFAULT,
-                y: i32 = win32.CW_USEDEFAULT,
-                nWidth: i32 = win32.CW_USEDEFAULT,
-                nHeight: i32 = win32.CW_USEDEFAULT,
+                dwExStyle: ui_window.WINDOW_EX_STYLE = .{},
+                x: i32 = ui_window.CW_USEDEFAULT,
+                y: i32 = ui_window.CW_USEDEFAULT,
+                nWidth: i32 = ui_window.CW_USEDEFAULT,
+                nHeight: i32 = ui_window.CW_USEDEFAULT,
                 hWndParent: ?HWND = null,
-                hMenu: ?win32.HMENU = null,
+                hMenu: ?ui_window.HMENU = null,
             },
-        ) win32.BOOL {
-            const wc = win32.WNDCLASS{
+        ) win32.foundation.BOOL {
+            const wc = ui_window.WNDCLASS{
                 .style = .{},
                 .lpfnWndProc = WindowProc,
                 .cbClsExtra = 0,
                 .cbWndExtra = 0,
-                .hInstance = win32.GetModuleHandle(null),
+                .hInstance = lib_loader.GetModuleHandle(null),
                 .hIcon = null,
                 .hCursor = null,
                 .hbrBackground = null,
                 // TODO: autogen bindings don't allow for null, should win32metadata allow Option for fields? Or should all strings allow NULL?
-                .lpszMenuName = L("Placeholder"),
+                .lpszMenuName = win32.zig.L("Placeholder"),
                 .lpszClassName = DERIVED_TYPE.ClassName(),
             };
 
-            _ = win32.RegisterClass(&wc);
+            _ = ui_window.RegisterClass(&wc);
 
-            self.m_hwnd = win32.CreateWindowEx(
+            self.m_hwnd = ui_window.CreateWindowEx(
                 options.dwExStyle,
                 DERIVED_TYPE.ClassName(),
                 lpWindowName,
@@ -79,11 +69,11 @@ pub fn BaseWindow(comptime DERIVED_TYPE: type) type {
                 options.nHeight,
                 options.hWndParent,
                 options.hMenu,
-                win32.GetModuleHandle(null),
+                lib_loader.GetModuleHandle(null),
                 @ptrCast(self),
             );
 
-            return if (self.m_hwnd != null) win32.TRUE else win32.FALSE;
+            return if (self.m_hwnd != null) win32.zig.TRUE else win32.zig.FALSE;
         }
 
         pub fn Window(self: @This()) ?HWND {

--- a/examples/d2dcircle.zig
+++ b/examples/d2dcircle.zig
@@ -1,19 +1,10 @@
 //! This example is ported from : https://github.com/microsoft/Windows-classic-samples/blob/master/Samples/Win7Samples/begin/LearnWin32/Direct2DCircle/cpp/main.cpp
 pub const UNICODE = true;
 
-const WINAPI = @import("std").os.windows.WINAPI;
-const win32 = struct {
-    usingnamespace @import("win32").zig;
-    usingnamespace @import("win32").foundation;
-    usingnamespace @import("win32").system.system_services;
-    usingnamespace @import("win32").ui.windows_and_messaging;
-    usingnamespace @import("win32").graphics.gdi;
-    usingnamespace @import("win32").graphics.direct2d;
-    usingnamespace @import("win32").graphics.direct2d.common;
-    usingnamespace @import("win32").graphics.direct3d9;
-    usingnamespace @import("win32").graphics.dxgi.common;
-    usingnamespace @import("win32").system.com;
-};
+const win32 = @import("win32").everything;
+// Needed for unicode aliases
+const ui_window = @import("win32").ui.windows_and_messaging;
+
 const L = win32.L;
 const FAILED = win32.FAILED;
 const SUCCEEDED = win32.SUCCEEDED;
@@ -158,10 +149,7 @@ fn MainWindowResize(self: *MainWindow) void {
     }
 }
 
-pub export fn wWinMain(_: HINSTANCE, __: ?HINSTANCE, ___: [*:0]u16, nCmdShow: u32) callconv(WINAPI) c_int {
-    _ = __;
-    _ = ___;
-
+pub export fn wWinMain(_: HINSTANCE, _: ?HINSTANCE, _: [*:0]u16, nCmdShow: u32) callconv(.winapi) c_int {
     var win = MainWindow{};
 
     if (win32.TRUE != win.base.Create(L("Circle"), win32.WS_OVERLAPPEDWINDOW, .{})) {
@@ -173,9 +161,9 @@ pub export fn wWinMain(_: HINSTANCE, __: ?HINSTANCE, ___: [*:0]u16, nCmdShow: u3
     // Run the message loop.
 
     var msg: MSG = undefined;
-    while (0 != win32.GetMessage(&msg, null, 0, 0)) {
-        _ = win32.TranslateMessage(&msg);
-        _ = win32.DispatchMessage(&msg);
+    while (0 != ui_window.GetMessage(&msg, null, 0, 0)) {
+        _ = ui_window.TranslateMessage(&msg);
+        _ = ui_window.DispatchMessage(&msg);
     }
 
     return 0;
@@ -213,7 +201,7 @@ fn MainWindowHandleMessage(self: *MainWindow, uMsg: u32, wParam: WPARAM, lParam:
         },
         else => {},
     }
-    return win32.DefWindowProc(self.base.m_hwnd.?, uMsg, wParam, lParam);
+    return ui_window.DefWindowProc(self.base.m_hwnd.?, uMsg, wParam, lParam);
 }
 
 // TODO: tthis D2D1 namespace is referenced in the C++ example but it doesn't exist in win32metadata

--- a/examples/helloworld.zig
+++ b/examples/helloworld.zig
@@ -1,6 +1,6 @@
 const win32 = @import("win32").everything;
 
-pub export fn WinMainCRTStartup() callconv(@import("std").os.windows.WINAPI) noreturn {
+pub export fn WinMainCRTStartup() callconv(.winapi) noreturn {
     const hStdOut = win32.GetStdHandle(win32.STD_OUTPUT_HANDLE);
     if (hStdOut == win32.INVALID_HANDLE_VALUE) {
         //std.debug.warn("Error: GetStdHandle failed with {}\n", .{GetLastError()});

--- a/examples/net.zig
+++ b/examples/net.zig
@@ -1,15 +1,12 @@
 //! test basic network functionality
 const std = @import("std");
 
-const win32 = struct {
-    usingnamespace @import("win32").foundation;
-    usingnamespace @import("win32").networking.win_sock;
-    usingnamespace @import("win32").network_management.ip_helper;
-};
+const win32 = @import("win32");
+const win_sock = win32.networking.win_sock;
 
 pub fn main() void {
-    const s = win32.socket(@intFromEnum(win32.AF_INET), win32.SOCK_STREAM, @intFromEnum(win32.IPPROTO_TCP));
-    if (s == win32.INVALID_SOCKET) {
-        std.log.err("socket failed, error={}", .{win32.GetLastError()});
+    const s = win_sock.socket(@intFromEnum(win_sock.AF_INET), win_sock.SOCK_STREAM, @intFromEnum(win_sock.IPPROTO_TCP));
+    if (s == win_sock.INVALID_SOCKET) {
+        std.log.err("socket failed, error={f}", .{win32.foundation.GetLastError()});
     }
 }

--- a/examples/opendialog.zig
+++ b/examples/opendialog.zig
@@ -1,17 +1,11 @@
 const std = @import("std");
 pub const UNICODE = true;
 
-const WINAPI = @import("std").os.windows.WINAPI;
-
 const win32 = @import("win32").everything;
 
 pub const panic = win32.messageBoxThenPanic(.{ .title = "Opendialog Example Panic" });
 
-pub export fn wWinMain(__: win32.HINSTANCE, _: ?win32.HINSTANCE, ___: [*:0]u16, ____: u32) callconv(WINAPI) c_int {
-    _ = __;
-    _ = ___;
-    _ = ____;
-
+pub export fn wWinMain(_: win32.HINSTANCE, _: ?win32.HINSTANCE, _: [*:0]u16, _: u32) callconv(.winapi) c_int {
     {
         const hr = win32.CoInitializeEx(null, win32.COINIT{
             .APARTMENTTHREADED = 1,

--- a/examples/testwindow.zig
+++ b/examples/testwindow.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const WINAPI = std.os.windows.WINAPI;
 
 const win32 = @import("win32").everything;
 const L = win32.L;
@@ -12,7 +11,7 @@ pub export fn wWinMain(
     _: ?win32.HINSTANCE,
     pCmdLine: [*:0]u16,
     nCmdShow: u32,
-) callconv(WINAPI) c_int {
+) callconv(.winapi) c_int {
     _ = pCmdLine;
     _ = nCmdShow;
 
@@ -35,7 +34,7 @@ pub export fn wWinMain(
     };
 
     if (0 == win32.RegisterClassW(&wc))
-        std.debug.panic("RegisterClass failed, error={}", .{win32.GetLastError()});
+        win32.panicWin32("RegisterClass", win32.GetLastError());
 
     const hwnd = win32.CreateWindowExW(
         .{},
@@ -50,7 +49,7 @@ pub export fn wWinMain(
         null, // menu
         hInstance,
         null, // Additional application data
-    ) orelse std.debug.panic("CreateWindow failed, error={}", .{win32.GetLastError()});
+    ) orelse win32.panicWin32("CreateWindow", win32.GetLastError());
 
     const dpi = win32.dpiFromHwnd(hwnd);
 
@@ -69,7 +68,7 @@ pub export fn wWinMain(
         win32.scaleDpi(i32, 600, dpi),
         win32.scaleDpi(i32, 400, dpi),
         .{ .NOMOVE = 1 },
-    )) std.debug.panic("SetWindowPos failed, error={}", .{win32.GetLastError()});
+    )) win32.panicWin32("SetWindowPos", win32.GetLastError());
 
     _ = win32.ShowWindow(hwnd, .{ .SHOWNORMAL = 1 });
 
@@ -86,7 +85,7 @@ fn WindowProc(
     uMsg: u32,
     wParam: win32.WPARAM,
     lParam: win32.LPARAM,
-) callconv(WINAPI) win32.LRESULT {
+) callconv(.winapi) win32.LRESULT {
     switch (uMsg) {
         win32.WM_CREATE => {
             if (win32.has_window_longptr) {

--- a/examples/wasapi.zig
+++ b/examples/wasapi.zig
@@ -2,16 +2,7 @@ const std = @import("std");
 
 const log = std.log.info;
 
-const win32 = struct {
-    usingnamespace @import("win32").foundation;
-    usingnamespace @import("win32").media.audio;
-    usingnamespace @import("win32").media.audio.direct_music;
-    usingnamespace @import("win32").storage.structured_storage;
-    usingnamespace @import("win32").system.com;
-    usingnamespace @import("win32").system.com.structured_storage;
-    usingnamespace @import("win32").ui.shell.properties_system;
-    usingnamespace @import("win32").zig;
-};
+const win32 = @import("win32").everything;
 
 pub fn getDefaultDevice() !void {
     var enumerator: *win32.IMMDeviceEnumerator = undefined;

--- a/src/StringPool.zig
+++ b/src/StringPool.zig
@@ -10,14 +10,7 @@ pub const Val = struct {
     pub fn eql(self: Val, other: Val) bool {
         return self.slice.ptr == other.slice.ptr;
     }
-    pub fn format(
-        self: @This(),
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: @This(), writer: *std.Io.Writer) !void {
         return writer.writeAll(self.slice);
     }
 };

--- a/src/common.zig
+++ b/src/common.zig
@@ -81,6 +81,10 @@ const JsonFormatter = struct {
     value: std.json.Value,
     pub fn format(self: JsonFormatter, writer: *std.Io.Writer) !void {
         switch (self.value) {
+            .float => |v| try writer.printFloat(v, .{
+                // Needed for large integer float values that can't be converted in zig 0.15
+                .mode = .scientific,
+            }),
             .number_string => |s| try writer.writeAll(s),
             else => try writer.print("{f}", .{std.json.fmt(self.value, .{})}),
         }

--- a/src/genzig.zig
+++ b/src/genzig.zig
@@ -638,7 +638,7 @@ fn generateContainerModules(dir: std.fs.Dir, module: *Module) anyerror!void {
     };
     defer file.close();
     var buf: [output_buf_size]u8 = undefined;
-    var file_writer = file.writer(&buf);
+    var file_writer = file.writerStreaming(&buf);
     const writer = &file_writer.interface;
     defer writer.flush() catch @panic("flush failed");
 

--- a/src/genzig.zig
+++ b/src/genzig.zig
@@ -1,7 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const zigexports = @import("zigexports");
-const ArrayList = std.ArrayList;
+const ArrayList = std.array_list.Managed;
 const StringHashMap = std.StringHashMap;
 const StringPool = @import("StringPool.zig");
 
@@ -227,7 +227,7 @@ pub fn main() !u8 {
     // no need to free pass1_json_content
     global_pass1 = pass1data.parseRoot(allocator, pass1_json, pass1_json_content);
     const api_list: []StringPool.Val = blk: {
-        var api_list = std.ArrayList(StringPool.Val).init(allocator);
+        var api_list = ArrayList(StringPool.Val).init(allocator);
         const api_path = try std.fs.path.join(allocator, &.{ win32json_path, "api" });
         var api_dir = try std.fs.cwd().openDir(api_path, .{ .iterate = true });
         defer api_dir.close();
@@ -919,7 +919,7 @@ fn generateFile(module_dir: std.fs.Dir, module: *Module, api: metadata.Api) !voi
                 return std.ascii.lessThanIgnoreCase(lhs.name.slice, rhs.name.slice);
             }
         };
-        var sorted_imports = std.ArrayList(NamedApiImport).init(allocator);
+        var sorted_imports = ArrayList(NamedApiImport).init(allocator);
         defer sorted_imports.deinit();
         {
             var it = sdk_file.top_level_api_imports.iterator();

--- a/src/genzig.zig
+++ b/src/genzig.zig
@@ -2305,17 +2305,10 @@ fn generateEnum(
                 try writer.line("// results in needing over 100Kb to store them as strings.");
                 try writer.line("// Instead, we use FormatMessage to access a string for each error.");
             }
-            try writer.line("pub fn format(");
-            try writer.linef("    self: {f},", .{pool_name});
-            try writer.line("    comptime fmt: []const u8,");
-            try writer.line("    options: @import(\"std\").fmt.FormatOptions,");
-            try writer.line("    writer: anytype,");
-            try writer.line(") !void {");
+            try writer.linef("pub fn format(self: {f}, writer: *@import(\"std\").Io.Writer) !void {{", .{pool_name});
             if (is_win32_error) {
-                try writer.line("    try @import(\"zig.zig\").fmtError(@intFromEnum(self)).format(fmt, options, writer);");
+                try writer.line("    try @import(\"zig.zig\").fmtError(@intFromEnum(self)).format(writer);");
             } else {
-                try writer.line("    _ = fmt;");
-                try writer.line("    _ = options;");
                 try writer.line("    try writer.print(\"{s}({})\", .{self.value.tagName() orelse \"?\", @intFromEnum(self.value)});");
             }
             try writer.line("}");

--- a/src/genzig.zig
+++ b/src/genzig.zig
@@ -365,9 +365,9 @@ pub fn main() !u8 {
         const w = &writer.interface;
         defer w.flush() catch @panic("flush failed");
         try w.writeAll(".{\n");
-        try w.writeAll("    .name = \"zigwin32\",\n");
+        try w.writeAll("    .name = .zigwin32,\n");
         try w.print("    .version = \"{f}\",\n", .{version});
-        try w.writeAll("    .minimum_zig_version = \"0.12.0\",\n");
+        try w.writeAll("    .minimum_zig_version = \"0.15.0\",\n");
         try w.writeAll("    .paths = .{\n");
         for (static_files) |name| {
             if (std.mem.eql(u8, name, ".gitignore")) continue;

--- a/src/genzigexports.zig
+++ b/src/genzigexports.zig
@@ -21,11 +21,12 @@ pub fn main() !void {
     const out_file = try std.fs.cwd().createFile(out_file_path, .{});
     defer out_file.close();
 
-    var bw = std.io.bufferedWriter(out_file.writer());
-    try generate(bw.writer().any());
-    try bw.flush();
+    var out_buf: [4096]u8 = undefined;
+    var w = out_file.writer(&out_buf);
+    try generate(&w.interface);
+    try w.interface.flush();
 }
-fn generate(writer: std.io.AnyWriter) !void {
+fn generate(writer: *std.Io.Writer) !void {
     try writer.writeAll("pub const Kind = enum { constant, type, function };\n");
     try writer.writeAll("pub const Decl = struct { kind: Kind, name: []const u8};\n");
     try writer.writeAll("pub const declarations = [_]Decl{\n");

--- a/src/pass1data.zig
+++ b/src/pass1data.zig
@@ -20,12 +20,12 @@ pub fn parseRoot(
         .{},
     ) catch |err| {
         std.log.err(
-            "{s}:{}:{}: {s}",
+            "{s}:{d}:{d}: {t}",
             .{
                 json_filename,
                 diagnostics.getLine(),
                 diagnostics.getColumn(),
-                @errorName(err),
+                err,
             },
         );
         @panic("json error");

--- a/test/badcomoverload.zig
+++ b/test/badcomoverload.zig
@@ -1,8 +1,8 @@
 const win32 = struct {
-    usingnamespace @import("win32").graphics.direct2d;
+    const direct2d = @import("win32").graphics.direct2d;
 };
 
 pub fn main() void {
-    var elem: *win32.ID2D1SvgElement = undefined;
+    var elem: *win32.direct2d.ID2D1SvgElement = undefined;
     elem.GetAttributeValue(0, 0, 0);
 }

--- a/test/comoverload.zig
+++ b/test/comoverload.zig
@@ -1,18 +1,17 @@
 const std = @import("std");
-const WINAPI = std.os.windows.WINAPI;
 const win32 = struct {
-    usingnamespace @import("win32").foundation;
-    usingnamespace @import("win32").graphics.direct2d;
-    usingnamespace @import("win32").zig;
+    const foundation = @import("win32").foundation;
+    const direct2d = @import("win32").graphics.direct2d;
+    const zig = @import("win32").zig;
 };
 
 fn GetAttributeValueString(
-    self: *const win32.ID2D1SvgElement,
+    self: *const win32.direct2d.ID2D1SvgElement,
     name: ?[*:0]const u16,
-    @"type": win32.D2D1_SVG_ATTRIBUTE_STRING_TYPE,
+    @"type": win32.direct2d.D2D1_SVG_ATTRIBUTE_STRING_TYPE,
     value: [*:0]u16,
     valueCount: u32,
-) callconv(WINAPI) win32.HRESULT {
+) callconv(.winapi) win32.foundation.HRESULT {
     _ = self;
     _ = name;
     _ = @"type";
@@ -22,15 +21,15 @@ fn GetAttributeValueString(
 }
 
 pub fn main() void {
-    var vtable: win32.ID2D1SvgElement.VTable = undefined;
+    var vtable: win32.direct2d.ID2D1SvgElement.VTable = undefined;
     vtable.GetAttributeValueString = &GetAttributeValueString;
-    var element_instance: win32.ID2D1SvgElement = .{
+    var element_instance: win32.direct2d.ID2D1SvgElement = .{
         .vtable = &vtable,
     };
     const element = &element_instance;
     var value_buf: [10:0]u16 = undefined;
     std.debug.assert(0 == element.GetAttributeValueString(
-        win32.L("Hello"),
+        win32.zig.L("Hello"),
         .SVG,
         &value_buf,
         value_buf.len,


### PR DESCRIPTION
Closes #50

I'm not sure if this repo needs to produce backwards compatible code. These changes only work in 0.15 and implementing a version check would be quite cumbersome since the std lib has changed.

This is needed for [dvui](https://github.com/david-vanderson/dvui/pull/529#issuecomment-3240031034)

I don't know how the release to https://github.com/marlersoft/zigwin32 works or the `diff` directory, so I haven't changed anything there.

Please let me know if I need to change anything! 